### PR TITLE
update go.mod and import paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/golang-fips/openssl-fips
+module github.com/golang-fips/openssl
 
 go 1.18

--- a/openssl/bbig/big.go
+++ b/openssl/bbig/big.go
@@ -10,7 +10,7 @@ import (
 	"math/big"
 	"unsafe"
 
-	"github.com/golang-fips/openssl-fips/openssl"
+	"github.com/golang-fips/openssl/openssl"
 )
 
 func Enc(b *big.Int) openssl.BigInt {

--- a/openssl/ecdh_test.go
+++ b/openssl/ecdh_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang-fips/openssl-fips/openssl"
+	"github.com/golang-fips/openssl/openssl"
 )
 
 func TestECDH(t *testing.T) {
@@ -157,7 +157,7 @@ func TestInvalidPublicKey(t *testing.T) {
 		// Points not on the curve.
 		"046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f6",
 		"0400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-	};
+	}
 
 	for _, input := range keys {
 		k, err := openssl.NewPublicKeyECDH("P-256", hexDecode(t, input))

--- a/openssl/ecdsa_test.go
+++ b/openssl/ecdsa_test.go
@@ -9,8 +9,8 @@ import (
 	"crypto/elliptic"
 	"testing"
 
-	"github.com/golang-fips/openssl-fips/openssl"
-	"github.com/golang-fips/openssl-fips/openssl/bbig"
+	"github.com/golang-fips/openssl/openssl"
+	"github.com/golang-fips/openssl/openssl/bbig"
 )
 
 func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {

--- a/openssl/openssl_test.go
+++ b/openssl/openssl_test.go
@@ -8,9 +8,8 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/golang-fips/openssl-fips/openssl"
+	"github.com/golang-fips/openssl/openssl"
 )
-
 
 func TestMain(m *testing.M) {
 	exitVal := m.Run()

--- a/openssl/rsa_test.go
+++ b/openssl/rsa_test.go
@@ -12,8 +12,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/golang-fips/openssl-fips/openssl"
-	"github.com/golang-fips/openssl-fips/openssl/bbig"
+	"github.com/golang-fips/openssl/openssl"
+	"github.com/golang-fips/openssl/openssl/bbig"
 )
 
 func fromBase16(base16 string) openssl.BigInt {


### PR DESCRIPTION
After changing the name of the repo from openssl-fips to simply openssl we must also update the go.mod file and import paths to ensure everything continues to build correctly.