### PR TITLE
Exclude port_evp_md5_sha1.c from non-linux OSes

### DIFF
--- a/port_evp_md5_sha1.c
+++ b/port_evp_md5_sha1.c
@@ -1,3 +1,6 @@
+//go:build linux && !android
+// +build linux,!android
+
 // The following is a partial backport of crypto/evp/m_md5_sha1.c,
 // commit cbc8a839959418d8a2c2e3ec6bdf394852c9501e on the
 // OpenSSL_1_1_0-stable branch.  The ctrl function has been removed.


### PR DESCRIPTION
The Microsoft fork fails to bootstrap on Windows if `port_evp_md5_sha1.c` is not excluded from the build.