### PR TITLE
Fix loopclosure vet check

### DIFF
--- a/hmac_test.go
+++ b/hmac_test.go
@@ -21,6 +21,7 @@ func TestHMAC(t *testing.T) {
 		{"sha512", NewSHA512},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			h := NewHMAC(tt.fn, nil)

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -17,6 +17,7 @@ import (
 
 func TestRSAKeyGeneration(t *testing.T) {
 	for _, size := range []int{2048, 3072} {
+		size := size
 		t.Run(strconv.Itoa(size), func(t *testing.T) {
 			t.Parallel()
 			priv, pub := newRSAKey(t, size)

--- a/sha_test.go
+++ b/sha_test.go
@@ -26,6 +26,7 @@ func TestSha(t *testing.T) {
 		{"sha512", openssl.NewSHA512},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			h := tt.fn()


### PR DESCRIPTION
Some tests using `t.Parallel` are not behaving as expected due to a loop variable being captured by a function closure.