### PR TITLE
Cache and pre-fetch EVP_MD objects

### DIFF
--- a/evp.go
+++ b/evp.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 )
 
+// cacheMD is a cache of crypto.Hash to GO_EVP_MD_PTR.
 var cacheMD sync.Map
 
 // hashToMD converts a hash.Hash implementation from this package to a GO_EVP_MD_PTR.

--- a/evp.go
+++ b/evp.go
@@ -10,28 +10,48 @@ import (
 	"errors"
 	"hash"
 	"strconv"
+	"sync"
 	"unsafe"
 )
 
+var cacheMD sync.Map
+
 // hashToMD converts a hash.Hash implementation from this package to a GO_EVP_MD_PTR.
 func hashToMD(h hash.Hash) C.GO_EVP_MD_PTR {
+	var ch crypto.Hash
 	switch h.(type) {
 	case *sha1Hash:
-		return C.go_openssl_EVP_sha1()
+		ch = crypto.SHA1
 	case *sha224Hash:
-		return C.go_openssl_EVP_sha224()
+		ch = crypto.SHA224
 	case *sha256Hash:
-		return C.go_openssl_EVP_sha256()
+		ch = crypto.SHA256
 	case *sha384Hash:
-		return C.go_openssl_EVP_sha384()
+		ch = crypto.SHA384
 	case *sha512Hash:
-		return C.go_openssl_EVP_sha512()
+		ch = crypto.SHA512
+	}
+	if ch != 0 {
+		return cryptoHashToMD(ch)
 	}
 	return nil
 }
 
 // cryptoHashToMD converts a crypto.Hash to a GO_EVP_MD_PTR.
-func cryptoHashToMD(ch crypto.Hash) C.GO_EVP_MD_PTR {
+func cryptoHashToMD(ch crypto.Hash) (md C.GO_EVP_MD_PTR) {
+	if v, ok := cacheMD.Load(ch); ok {
+		return v.(C.GO_EVP_MD_PTR)
+	}
+	defer func() {
+		if md != nil && vMajor == 3 {
+			// On OpenSSL 3, directly operating on a EVP_MD object
+			// not created by EVP_MD_fetch has negative performance
+			// implications, as digest operations will have
+			// to fetch it on every call. Better to just fetch it once here.
+			md = C.go_openssl_EVP_MD_fetch(nil, C.go_openssl_EVP_MD_get0_name(md), nil)
+		}
+		cacheMD.Store(ch, md)
+	}()
 	switch ch {
 	case crypto.MD5:
 		return C.go_openssl_EVP_md5()


### PR DESCRIPTION
This PR implements the following OpenSSL performance guidelines:

- EVP_MD objects should be fetched just once and used for multiple calls to other operations such as EVP_DigestInit_ex().
- (For OpenSSL 3) If you perform the same operation many times then it is recommended to use ["Explicit fetching"](https://www.openssl.org/docs/man3.0/man7/crypto.html#Explicit-fetching) to prefetch an algorithm once initially, and then pass this created object to any operations that are currently using ["Implicit fetching"](https://www.openssl.org/docs/man3.0/man7/crypto.html#Implicit-fetching).

See ["Performance" in crypto(7)](https://www.openssl.org/docs/man3.0/man7/crypto.html) for further information.