### PR TITLE
Cache and pre-fetch EVP_CIPHER objects

### DIFF
--- a/evp.go
+++ b/evp.go
@@ -14,6 +14,7 @@ import (
 	"unsafe"
 )
 
+// cacheMD is a cache of crypto.Hash to GO_EVP_MD_PTR.
 var cacheMD sync.Map
 
 // hashToMD converts a hash.Hash implementation from this package to a GO_EVP_MD_PTR.

--- a/evp.go
+++ b/evp.go
@@ -10,28 +10,48 @@ import (
 	"errors"
 	"hash"
 	"strconv"
+	"sync"
 	"unsafe"
 )
 
+var cacheMD sync.Map
+
 // hashToMD converts a hash.Hash implementation from this package to a GO_EVP_MD_PTR.
 func hashToMD(h hash.Hash) C.GO_EVP_MD_PTR {
+	var ch crypto.Hash
 	switch h.(type) {
 	case *sha1Hash:
-		return C.go_openssl_EVP_sha1()
+		ch = crypto.SHA1
 	case *sha224Hash:
-		return C.go_openssl_EVP_sha224()
+		ch = crypto.SHA224
 	case *sha256Hash:
-		return C.go_openssl_EVP_sha256()
+		ch = crypto.SHA256
 	case *sha384Hash:
-		return C.go_openssl_EVP_sha384()
+		ch = crypto.SHA384
 	case *sha512Hash:
-		return C.go_openssl_EVP_sha512()
+		ch = crypto.SHA512
+	}
+	if ch != 0 {
+		return cryptoHashToMD(ch)
 	}
 	return nil
 }
 
 // cryptoHashToMD converts a crypto.Hash to a GO_EVP_MD_PTR.
-func cryptoHashToMD(ch crypto.Hash) C.GO_EVP_MD_PTR {
+func cryptoHashToMD(ch crypto.Hash) (md C.GO_EVP_MD_PTR) {
+	if v, ok := cacheMD.Load(ch); ok {
+		return v.(C.GO_EVP_MD_PTR)
+	}
+	defer func() {
+		if md != nil && vMajor == 3 {
+			// On OpenSSL 3, directly operating on a EVP_MD object
+			// not created by EVP_MD_fetch has negative performance
+			// implications, as digest operations will have
+			// to fetch it on every call. Better to just fetch it once here.
+			md = C.go_openssl_EVP_MD_fetch(nil, C.go_openssl_EVP_MD_get0_name(md), nil)
+		}
+		cacheMD.Store(ch, md)
+	}()
 	switch ch {
 	case crypto.MD5:
 		return C.go_openssl_EVP_md5()

--- a/shims.h
+++ b/shims.h
@@ -220,6 +220,8 @@ DEFINEFUNC(int, EVP_EncryptUpdate, (GO_EVP_CIPHER_CTX_PTR ctx, unsigned char *ou
 DEFINEFUNC(int, EVP_EncryptFinal_ex, (GO_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl), (ctx, out, outl)) \
 DEFINEFUNC(int, EVP_DecryptUpdate, (GO_EVP_CIPHER_CTX_PTR ctx, unsigned char *out, int *outl, const unsigned char *in, int inl),	(ctx, out, outl, in, inl)) \
 DEFINEFUNC(int, EVP_DecryptFinal_ex, (GO_EVP_CIPHER_CTX_PTR ctx, unsigned char *outm, int *outl),	(ctx, outm, outl)) \
+DEFINEFUNC_3_0(GO_EVP_CIPHER_PTR, EVP_CIPHER_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
+DEFINEFUNC_3_0(const char *, EVP_CIPHER_get0_name, (const GO_EVP_CIPHER_PTR cipher), (cipher)) \
 DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_aes_128_gcm, (void), ()) \
 DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_aes_128_cbc, (void), ()) \
 DEFINEFUNC(const GO_EVP_CIPHER_PTR, EVP_aes_128_ctr, (void), ()) \


### PR DESCRIPTION
Same as #75 but for `EVP_CIPHER` objects,