### PR TITLE
hmac: avoid passing the key when calling Reset() on OpenSSL 3.0.3+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.19.x]
-        openssl-version: [1.0.2, 1.1.0, 1.1.1, 3.0.1]
+        openssl-version: [1.0.2, 1.1.0, 1.1.1, 3.0.1, 3.0.9]
     runs-on: ubuntu-20.04
     steps:
     - name: Install build tools

--- a/hmac.go
+++ b/hmac.go
@@ -115,9 +115,10 @@ func newHMAC3(key []byte, h hash.Hash, md C.GO_EVP_MD_PTR) *opensslHMAC {
 	}
 	var hkey []byte
 	if vMinor == 0 && vPatch <= 2 {
-		// EVP_MAC_init only reset the ctx internal state if a key is passed
-		// when using OpenSSL 3.0.0, 3.0.1, and 3.0.2. New OpenSSL versions
-		// do not have this issue.
+		// EVP_MAC_init only resets the ctx internal state if a key is passed
+		// when using OpenSSL 3.0.0, 3.0.1, and 3.0.2. Save a copy of the key
+		// in the context so Reset can use it later. New OpenSSL versions
+		// do not have this issue so it isn't necessary to save the key.
 		// See https://github.com/openssl/openssl/issues/17811.
 		hkey = make([]byte, len(key))
 		copy(hkey, key)

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -14,24 +14,35 @@ case "$version" in
         sha256="82fa58e3f273c53128c6fe7e3635ec8cda1319a10ce1ad50a987c3df0deeef05"
         config="shared"
         make="build_libs"
+        install=""
         ;;
     "1.1.0")
         tag="OpenSSL_1_1_0l"
         sha256="e2acf0cf58d9bff2b42f2dc0aee79340c8ffe2c5e45d3ca4533dd5d4f5775b1d"
         config="shared"
         make="build_libs"
+        install=""
         ;;
     "1.1.1")
         tag="OpenSSL_1_1_1m"
         sha256="36ae24ad7cf0a824d0b76ac08861262e47ec541e5d0f20e6d94bab90b2dab360"
         config="shared"
         make="build_libs"
+        install=""
         ;;
     "3.0.1")
         tag="openssl-3.0.1";
         sha256="2a9dcf05531e8be96c296259e817edc41619017a4bf3e229b4618a70103251d5"
-        config="shared enable-fips"
-        make="install_fips"
+        config="enable-fips"
+        make="build_libs"
+        install="install_fips"
+        ;;
+    "3.0.9")
+        tag="openssl-3.0.9";
+        sha256="2eec31f2ac0e126ff68d8107891ef534159c4fcfb095365d4cd4dc57d82616ee"
+        config="enable-fips"
+        make="build_libs"
+        install="install_fips"
         ;;
     *)
         echo >&2 "error: unsupported OpenSSL version '$version'"
@@ -52,5 +63,8 @@ cd "openssl-$version"
 # other problems. It's not necessary for normal use.
 ./config -d $config
 make -j$(nproc) $make
+if [ -n "$install" ]; then
+    make $install
+fi
 
 cp -H ./libcrypto.so "/usr/lib/libcrypto.so.${version}"


### PR DESCRIPTION
This PR optimizes `opensslHMAC.Reset` for OpenSSL 3.0.3 and higher versions, in which we don't have to pass the key thanks to https://github.com/openssl/openssl/issues/17811 being fixed.

The perf wins are remarkable:

```cmd
goos: linux
goarch: amd64
pkg: github.com/golang-fips/openssl
cpu: AMD EPYC 7763 64-Core Processor                
                   │   old.txt   │               new.txt               │
                   │   sec/op    │   sec/op     vs base                │
HMACSHA256_32-16     1.338µ ± 0%   1.093µ ± 2%  -18.32% (p=0.000 n=10)
HMACNewWriteSum-16   5.296µ ± 3%   5.374µ ± 4%        ~ (p=0.529 n=10)
geomean              2.661µ        2.423µ        -8.95%

                   │   old.txt    │               new.txt                │
                   │     B/s      │     B/s       vs base                │
HMACSHA256_32-16     22.82Mi ± 0%   27.94Mi ± 2%  +22.44% (p=0.000 n=10)
HMACNewWriteSum-16   5.765Mi ± 3%   5.679Mi ± 4%        ~ (p=0.516 n=10)
geomean              11.47Mi        12.60Mi        +9.83%

                   │  old.txt   │               new.txt               │
                   │    B/op    │    B/op     vs base                 │
HMACSHA256_32-16     80.00 ± 0%   80.00 ± 0%       ~ (p=1.000 n=10) ¹
HMACNewWriteSum-16   352.0 ± 0%   320.0 ± 0%  -9.09% (p=0.000 n=10)
geomean              167.8        160.0       -4.65%
¹ all samples are equal

                   │   old.txt   │               new.txt                │
                   │  allocs/op  │ allocs/op   vs base                  │
HMACSHA256_32-16      3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=10) ¹
HMACNewWriteSum-16   10.000 ± 0%   9.000 ± 0%  -10.00% (p=0.000 n=10)
geomean               5.477        5.196        -5.13%
¹ all samples are equal
```
