### PR TITLE
sha: use EVP_DIGEST instead of go_shaX

### DIFF
--- a/goopenssl.h
+++ b/goopenssl.h
@@ -60,20 +60,6 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_RENAMED_1_1
 #undef DEFINEFUNC_RENAMED_3_0
 
-// go_shaX is a SHA generic wrapper which hash p into out.
-// One shot sha functions are expected to be fast, so
-// we maximize performance by batching all cgo calls.
-static inline int
-go_shaX(GO_EVP_MD_PTR md, const void *p, size_t n, void *out)
-{
-    GO_EVP_MD_CTX_PTR ctx = go_openssl_EVP_MD_CTX_new();
-    go_openssl_EVP_DigestInit_ex(ctx, md, NULL);
-    int ret = go_openssl_EVP_DigestUpdate(ctx, p, n) &&
-        go_openssl_EVP_DigestFinal_ex(ctx, out, NULL);
-    go_openssl_EVP_MD_CTX_free(ctx);
-    return ret;
-}
-
 // These wrappers allocate out_len on the C stack to avoid having to pass a pointer from Go, which would escape to the heap.
 // Use them only in situations where the output length can be safely discarded.
 static inline int

--- a/sha.go
+++ b/sha.go
@@ -26,7 +26,7 @@ import (
 // This is all to preserve compatibility with the allocation behavior of the non-openssl implementations.
 
 func shaX(ch crypto.Hash, p []byte, sum []byte) bool {
-	return C.go_shaX(cryptoHashToMD(ch), unsafe.Pointer(&*addr(p)), C.size_t(len(p)), unsafe.Pointer(&*addr(sum))) != 0
+	return C.go_openssl_EVP_Digest(unsafe.Pointer(&*addr(p)), C.size_t(len(p)), (*C.uchar)(unsafe.Pointer(&*addr(sum))), nil, cryptoHashToMD(ch), nil) != 0
 }
 
 func SHA1(p []byte) (sum [20]byte) {

--- a/shims.h
+++ b/shims.h
@@ -181,10 +181,10 @@ DEFINEFUNC(int, RAND_bytes, (unsigned char* arg0, int arg1), (arg0, arg1)) \
 DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (), ()) \
 DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \
 DEFINEFUNC(int, EVP_MD_CTX_copy, (GO_EVP_MD_CTX_PTR out, const GO_EVP_MD_CTX_PTR in), (out, in)) \
+DEFINEFUNC(int, EVP_Digest, (const void *data, size_t count, unsigned char *md, unsigned int *size, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (data, count, md, size, type, impl)) \
 DEFINEFUNC(int, EVP_DigestInit_ex, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR impl), (ctx, type, impl)) \
 DEFINEFUNC(int, EVP_DigestInit, (GO_EVP_MD_CTX_PTR ctx, const GO_EVP_MD_PTR type), (ctx, type)) \
 DEFINEFUNC(int, EVP_DigestUpdate, (GO_EVP_MD_CTX_PTR ctx, const void *d, size_t cnt), (ctx, d, cnt)) \
-DEFINEFUNC(int, EVP_DigestFinal_ex, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
 DEFINEFUNC(int, EVP_DigestFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *md, unsigned int *s), (ctx, md, s)) \
 DEFINEFUNC(int, EVP_DigestSignInit, (GO_EVP_MD_CTX_PTR ctx, GO_EVP_PKEY_CTX_PTR *pctx, const GO_EVP_MD_PTR type, GO_ENGINE_PTR e, GO_EVP_PKEY_PTR pkey), (ctx, pctx, type, e, pkey)) \
 DEFINEFUNC(int, EVP_DigestSignFinal, (GO_EVP_MD_CTX_PTR ctx, unsigned char *sig, size_t *siglen), (ctx, sig, siglen)) \


### PR DESCRIPTION
This PR is a clean-up opportunity I saw recently. We don't need to implement a one-shot digest function ourselves, all supported OpenSSL versions already provide [EVP_Digest](https://www.openssl.org/docs/man3.0/man3/EVP_Digest.html). This function has the nice benefit of being a little bit faster on OpenSSL 3, thanks to setting the `EVP_MD_CTX_FLAG_ONESHOT` flag.

```cmd
goos: linux
goarch: amd64
pkg: github.com/golang-fips/openssl
cpu: AMD EPYC 7763 64-Core Processor                
          │   new.txt   │              new2.txt              │
          │   sec/op    │   sec/op     vs base               │
SHA256-16   287.9n ± 1%   283.8n ± 1%  -1.46% (p=0.003 n=10)

          │   new.txt    │              new2.txt               │
          │     B/s      │     B/s       vs base               │
SHA256-16   26.49Mi ± 1%   26.89Mi ± 1%  +1.49% (p=0.002 n=10)
¹ all samples are equal
```