### PR TITLE
sha: fix use-after-free issue

### DIFF
--- a/sha.go
+++ b/sha.go
@@ -127,6 +127,7 @@ func (h *evpHash) WriteString(s string) (int, error) {
 	if len(s) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(hdr.Data), C.size_t(len(s))) == 0 {
 		panic("openssl: EVP_DigestUpdate failed")
 	}
+	runtime.KeepAlive(h)
 	return len(s), nil
 }
 
@@ -134,6 +135,7 @@ func (h *evpHash) WriteByte(c byte) error {
 	if C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(&c), 1) == 0 {
 		panic("openssl: EVP_DigestUpdate failed")
 	}
+	runtime.KeepAlive(h)
 	return nil
 }
 


### PR DESCRIPTION
There is a possible use-after-free issue in `evpHash.WriteString` and in `evpHash.WriteByte`. They both pass `h.ctx` to `EVP_DigestUpdate` without making sure `h` is still alive until the cgo call ends, i.e. using `runtime.KeepAlive(h)`.

If the garbage collector chimes in at the right time, it will collect `h`, calling it's finalizer, that free's `h.ctx`, likely producing an invalid access exception.

Ported from https://github.com/microsoft/go-crypto-openssl/pull/55.