### PR TITLE
rsa: don't use deprecated OpenSSL APIs to contruct keys

### DIFF
--- a/rsa.go
+++ b/rsa.go
@@ -59,7 +59,7 @@ func GenerateKeyRSA(bits int) (N, E, D, P, Q, Dp, Dq, Qinv BigInt, err error) {
 			return bad(newOpenSSLError("BN_new failed"))
 		}
 		defer func() {
-			C.go_openssl_BN_clear(tmp)
+			C.go_openssl_BN_clear_free(tmp)
 		}()
 		var err error
 		setBigInt := func(bi *BigInt, param *C.char) bool {

--- a/shims.h
+++ b/shims.h
@@ -279,6 +279,7 @@ DEFINEFUNC_1_1(void, RSA_get0_factors, (const GO_RSA_PTR rsa, const GO_BIGNUM_PT
 DEFINEFUNC_1_1(void, RSA_get0_key, (const GO_RSA_PTR rsa, const GO_BIGNUM_PTR *n, const GO_BIGNUM_PTR *e, const GO_BIGNUM_PTR *d), (rsa, n, e, d)) \
 DEFINEFUNC(GO_BIGNUM_PTR, BN_new, (void), ()) \
 DEFINEFUNC(void, BN_free, (GO_BIGNUM_PTR arg0), (arg0)) \
+DEFINEFUNC(void, BN_clear, (GO_BIGNUM_PTR arg0), (arg0)) \
 DEFINEFUNC(void, BN_clear_free, (GO_BIGNUM_PTR arg0), (arg0)) \
 DEFINEFUNC(int, BN_num_bits, (const GO_BIGNUM_PTR arg0), (arg0)) \
 DEFINEFUNC(GO_BIGNUM_PTR, BN_bin2bn, (const unsigned char *arg0, int arg1, GO_BIGNUM_PTR arg2), (arg0, arg1, arg2)) \


### PR DESCRIPTION
This PR updates `GenerateKeyRSA`, `NewPublicKeyRSA`, and `NewPrivateKeyRSA` so they don't use deprecated OpenSSL 3 APIs when constructing a RSA key.