### PR TITLE
sha: Add SHA3 implementation

### DIFF
--- a/cmd/checkheader/main.go
+++ b/cmd/checkheader/main.go
@@ -288,6 +288,8 @@ func tryConvertDefineFunc(w io.Writer, l string, i int) bool {
 		writeDefineFunc("OPENSSL_VERSION_NUMBER < 0x30000000L")
 	case "DEFINEFUNC_1_1":
 		writeDefineFunc("OPENSSL_VERSION_NUMBER >= 0x10100000L")
+	case "DEFINEFUNC_1_1_1":
+		writeDefineFunc("OPENSSL_VERSION_NUMBER >= 0x10101000L")
 	case "DEFINEFUNC_3_0":
 		writeDefineFunc("OPENSSL_VERSION_NUMBER >= 0x30000000L")
 	case "DEFINEFUNC_RENAMED_1_1":

--- a/evp.go
+++ b/evp.go
@@ -31,6 +31,14 @@ func hashToMD(h hash.Hash) C.GO_EVP_MD_PTR {
 		ch = crypto.SHA384
 	case *sha512Hash:
 		ch = crypto.SHA512
+	case *sha3_224Hash:
+		ch = crypto.SHA3_224
+	case *sha3_256Hash:
+		ch = crypto.SHA3_256
+	case *sha3_384Hash:
+		ch = crypto.SHA3_384
+	case *sha3_512Hash:
+		ch = crypto.SHA3_512
 	}
 	if ch != 0 {
 		return cryptoHashToMD(ch)
@@ -72,6 +80,26 @@ func cryptoHashToMD(ch crypto.Hash) (md C.GO_EVP_MD_PTR) {
 		return C.go_openssl_EVP_sha384()
 	case crypto.SHA512:
 		return C.go_openssl_EVP_sha512()
+	case crypto.SHA3_224:
+		if !SupportsSHA3() {
+			return nil
+		}
+		return C.go_openssl_EVP_sha3_224()
+	case crypto.SHA3_256:
+		if !SupportsSHA3() {
+			return nil
+		}
+		return C.go_openssl_EVP_sha3_256()
+	case crypto.SHA3_384:
+		if !SupportsSHA3() {
+			return nil
+		}
+		return C.go_openssl_EVP_sha3_384()
+	case crypto.SHA3_512:
+		if !SupportsSHA3() {
+			return nil
+		}
+		return C.go_openssl_EVP_sha3_512()
 	}
 	return nil
 }

--- a/goopenssl.c
+++ b/goopenssl.c
@@ -13,6 +13,7 @@
 #define DEFINEFUNC_LEGACY_1_0(ret, func, args, argscall)       DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_LEGACY_1(ret, func, args, argscall)         DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_1_1(ret, func, args, argscall)              DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_1_1_1(ret, func, args, argscall)            DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_3_0(ret, func, args, argscall)              DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED_1_1(ret, func, oldfunc, args, argscall) DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED_3_0(ret, func, oldfunc, args, argscall) DEFINEFUNC(ret, func, args, argscall)
@@ -23,6 +24,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_LEGACY_1_0
 #undef DEFINEFUNC_LEGACY_1
 #undef DEFINEFUNC_1_1
+#undef DEFINEFUNC_1_1_1
 #undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1
 #undef DEFINEFUNC_RENAMED_3_0
@@ -52,7 +54,7 @@ go_openssl_fips_enabled(void* handle)
 // and assign them to their corresponding function pointer
 // defined in goopenssl.h.
 void
-go_openssl_load_functions(void* handle, int major, int minor)
+go_openssl_load_functions(void* handle, int major, int minor, int patch)
 {
 #define DEFINEFUNC_INTERNAL(name, func)                                                                         \
     _g_##name = dlsym(handle, func);                                                                            \
@@ -74,6 +76,11 @@ go_openssl_load_functions(void* handle, int major, int minor)
     }
 #define DEFINEFUNC_1_1(ret, func, args, argscall)     \
     if (major == 3 || (major == 1 && minor == 1))     \
+    {                                                 \
+        DEFINEFUNC_INTERNAL(func, #func)              \
+    }
+#define DEFINEFUNC_1_1_1(ret, func, args, argscall)     \
+    if (major == 3 || (major == 1 && minor == 1 && patch == 1))     \
     {                                                 \
         DEFINEFUNC_INTERNAL(func, #func)              \
     }
@@ -107,6 +114,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_LEGACY_1_0
 #undef DEFINEFUNC_LEGACY_1
 #undef DEFINEFUNC_1_1
+#undef DEFINEFUNC_1_1_1
 #undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1
 #undef DEFINEFUNC_RENAMED_3_0

--- a/goopenssl.h
+++ b/goopenssl.h
@@ -24,7 +24,7 @@ int go_openssl_version_major(void* handle);
 int go_openssl_version_minor(void* handle);
 int go_openssl_version_patch(void* handle);
 int go_openssl_thread_setup(void);
-void go_openssl_load_functions(void* handle, int major, int minor);
+void go_openssl_load_functions(void* handle, int major, int minor, int patch);
 const GO_EVP_MD_PTR go_openssl_EVP_md5_sha1_backport(void);
 
 // Define pointers to all the used OpenSSL functions.
@@ -43,6 +43,8 @@ const GO_EVP_MD_PTR go_openssl_EVP_md5_sha1_backport(void);
     DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_1_1(ret, func, args, argscall)   \
     DEFINEFUNC(ret, func, args, argscall)
+#define DEFINEFUNC_1_1_1(ret, func, args, argscall)     \
+    DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_3_0(ret, func, args, argscall)     \
     DEFINEFUNC(ret, func, args, argscall)
 #define DEFINEFUNC_RENAMED_1_1(ret, func, oldfunc, args, argscall)     \
@@ -56,6 +58,7 @@ FOR_ALL_OPENSSL_FUNCTIONS
 #undef DEFINEFUNC_LEGACY_1_0
 #undef DEFINEFUNC_LEGACY_1
 #undef DEFINEFUNC_1_1
+#undef DEFINEFUNC_1_1_1
 #undef DEFINEFUNC_3_0
 #undef DEFINEFUNC_RENAMED_1_1
 #undef DEFINEFUNC_RENAMED_3_0

--- a/init.go
+++ b/init.go
@@ -47,7 +47,7 @@ func opensslInit(version string) (major, minor, patch int, err error) {
 
 	// Load the OpenSSL functions.
 	// See shims.go for the complete list of supported functions.
-	C.go_openssl_load_functions(handle, C.int(major), C.int(minor))
+	C.go_openssl_load_functions(handle, C.int(major), C.int(minor), C.int(patch))
 
 	// Initialize OpenSSL.
 	C.go_openssl_OPENSSL_init()

--- a/sha.go
+++ b/sha.go
@@ -64,6 +64,41 @@ func SHA512(p []byte) (sum [64]byte) {
 	return
 }
 
+// Same as SupportsHKDF, as in v1.1.1+
+func SupportsSHA3() bool {
+	return vMajor > 1 ||
+		(vMajor >= 1 && vMinor > 1) ||
+		(vMajor >= 1 && vMinor >= 1 && vPatch >= 1)
+}
+
+func SHA3_224(p []byte) (sum [28]byte) {
+	if !shaX(crypto.SHA3_224, p, sum[:]) {
+		panic("openssl: SHA3_224 failed")
+	}
+	return
+}
+
+func SHA3_256(p []byte) (sum [32]byte) {
+	if !shaX(crypto.SHA3_256, p, sum[:]) {
+		panic("openssl: SHA3_256 failed")
+	}
+	return
+}
+
+func SHA3_384(p []byte) (sum [48]byte) {
+	if !shaX(crypto.SHA3_384, p, sum[:]) {
+		panic("openssl: SHA3_384 failed")
+	}
+	return
+}
+
+func SHA3_512(p []byte) (sum [64]byte) {
+	if !shaX(crypto.SHA3_512, p, sum[:]) {
+		panic("openssl: SHA3_512 failed")
+	}
+	return
+}
+
 // evpHash implements generic hash methods.
 type evpHash struct {
 	ctx C.GO_EVP_MD_CTX_PTR
@@ -557,6 +592,74 @@ func (h *sha512Hash) UnmarshalBinary(b []byte) error {
 	d.nh = n >> 61
 	d.nx = uint32(n) % 128
 	return nil
+}
+
+// NewSHA3_224 returns a new SHA3-224 hash.
+func NewSHA3_224() hash.Hash {
+	return &sha3_224Hash{
+		evpHash: newEvpHash(crypto.SHA3_224, 224/8, 64),
+	}
+}
+
+type sha3_224Hash struct {
+	*evpHash
+	out [224 / 8]byte
+}
+
+func (h *sha3_224Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
+}
+
+// NewSHA3_256 returns a new SHA3-256 hash.
+func NewSHA3_256() hash.Hash {
+	return &sha3_256Hash{
+		evpHash: newEvpHash(crypto.SHA3_256, 256/8, 64),
+	}
+}
+
+type sha3_256Hash struct {
+	*evpHash
+	out [256 / 8]byte
+}
+
+func (h *sha3_256Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
+}
+
+// NewSHA3_384 returns a new SHA3-384 hash.
+func NewSHA3_384() hash.Hash {
+	return &sha3_384Hash{
+		evpHash: newEvpHash(crypto.SHA3_384, 384/8, 128),
+	}
+}
+
+type sha3_384Hash struct {
+	*evpHash
+	out [384 / 8]byte
+}
+
+func (h *sha3_384Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
+}
+
+// NewSHA3_512 returns a new SHA3-512 hash.
+func NewSHA3_512() hash.Hash {
+	return &sha3_512Hash{
+		evpHash: newEvpHash(crypto.SHA3_512, 512/8, 128),
+	}
+}
+
+type sha3_512Hash struct {
+	*evpHash
+	out [512 / 8]byte
+}
+
+func (h *sha3_512Hash) Sum(in []byte) []byte {
+	h.sum(h.out[:])
+	return append(in, h.out[:]...)
 }
 
 // appendUint64 appends x into b as a big endian byte sequence.

--- a/shims.h
+++ b/shims.h
@@ -134,6 +134,9 @@ typedef void* GO_SHA_CTX_PTR;
 // DEFINEFUNC_1_1 acts like DEFINEFUNC but only aborts the process if function can't be loaded
 // when using 1.1.0 or higher.
 //
+// DEFINEFUNC_1_1_1 acts like DEFINEFUNC but only aborts the process if function can't be loaded
+// when using 1.1.1 or higher.
+//
 // DEFINEFUNC_3_0 acts like DEFINEFUNC but only aborts the process if function can't be loaded
 // when using 3.0.0 or higher.
 //
@@ -203,6 +206,10 @@ DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha224, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha256, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha384, (void), ()) \
 DEFINEFUNC(const GO_EVP_MD_PTR, EVP_sha512, (void), ()) \
+DEFINEFUNC_1_1_1(const GO_EVP_MD_PTR, EVP_sha3_224, (void), ()) \
+DEFINEFUNC_1_1_1(const GO_EVP_MD_PTR, EVP_sha3_256, (void), ()) \
+DEFINEFUNC_1_1_1(const GO_EVP_MD_PTR, EVP_sha3_384, (void), ()) \
+DEFINEFUNC_1_1_1(const GO_EVP_MD_PTR, EVP_sha3_512, (void), ()) \
 DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_init, (GO_HMAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC_LEGACY_1_0(void, HMAC_CTX_cleanup, (GO_HMAC_CTX_PTR arg0), (arg0)) \
 DEFINEFUNC(int, HMAC_Init_ex, (GO_HMAC_CTX_PTR arg0, const void *arg1, int arg2, const GO_EVP_MD_PTR arg3, GO_ENGINE_PTR arg4), (arg0, arg1, arg2, arg3, arg4)) \

--- a/xcrypto/sha3/sha3.go
+++ b/xcrypto/sha3/sha3.go
@@ -1,0 +1,45 @@
+package sha3
+
+// Drop-in replacement for golang.org/x/crypto/sha3
+// Assumes openssl.Init() was called
+
+import (
+	"crypto"
+	"hash"
+	"github.com/golang-fips/openssl"
+)
+
+func init() {
+	crypto.RegisterHash(crypto.SHA3_224, openssl.NewSHA3_224)
+	crypto.RegisterHash(crypto.SHA3_256, openssl.NewSHA3_256)
+	crypto.RegisterHash(crypto.SHA3_384, openssl.NewSHA3_384)
+	crypto.RegisterHash(crypto.SHA3_512, openssl.NewSHA3_512)
+}
+
+func New224() hash.Hash {
+	return openssl.NewSHA3_224()
+}
+func New256() hash.Hash {
+	return openssl.NewSHA3_256()
+}
+func New384() hash.Hash {
+	return openssl.NewSHA3_384()
+}
+func New512() hash.Hash {
+	return openssl.NewSHA3_512()
+}
+func Sum224(p []byte) (sum [28]byte) {
+	return openssl.SHA3_224(p)
+}
+
+func Sum256(p []byte) (sum [32]byte) {
+	return openssl.SHA3_256(p)
+}
+
+func Sum384(p []byte) (sum [48]byte) {
+	return openssl.SHA3_384(p)
+}
+
+func Sum512(p []byte) (sum [64]byte) {
+	return openssl.SHA3_512(p)
+}


### PR DESCRIPTION
This adds OpenSSL SHA-3 family of hashes in the openssl package.

Separately sha3 package is added as a drop-in replacement for golang.org/x/crypto/sha3 package.

Together with FIPS-compliant Go toolchain one can thus attempt building FIPS-compliant applications that use "crypto" package and also need FIPS-compliant SHA-3.

Ideally, a patched golang toolchain will use openssl/xcrypto/sha3 in place of any imports of golang.org/x/crypto/sha3, this is a future improvement to ensure golang-fips toolchain provides FIPS SHA3 without source changes.

Fixes: https://github.com/golang-fips/openssl/issues/87