### PR TITLE
remove !android build tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ OpenSSL is used for a given build only in limited circumstances:
 
 - The platform must be `GOOS=linux`.
 - The build must set `CGO_ENABLED=1`.
-- The android build tag must not be specified.
 
 ## Acknowledgements
 

--- a/aes.go
+++ b/aes.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/aes_test.go
+++ b/aes_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/ec.go
+++ b/ec.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/ecdh.go
+++ b/ecdh.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/ecdh_test.go
+++ b/ecdh_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl_test
 

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl_test
 

--- a/evp.go
+++ b/evp.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/goopenssl.c
+++ b/goopenssl.c
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 #include "goopenssl.h"
 

--- a/hkdf.go
+++ b/hkdf.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/hkdf_test.go
+++ b/hkdf_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl_test
 

--- a/hmac.go
+++ b/hmac.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/init.go
+++ b/init.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/openssl.go
+++ b/openssl.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 // Package openssl provides access to OpenSSL cryptographic functions.
 package openssl

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl_test
 

--- a/port_evp_md5_sha1.c
+++ b/port_evp_md5_sha1.c
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 // The following is a partial backport of crypto/evp/m_md5_sha1.c,
 // commit cbc8a839959418d8a2c2e3ec6bdf394852c9501e on the

--- a/rand.go
+++ b/rand.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/rand_test.go
+++ b/rand_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl_test
 

--- a/rsa.go
+++ b/rsa.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl_test
 

--- a/sha.go
+++ b/sha.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl
 

--- a/sha_test.go
+++ b/sha_test.go
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 package openssl_test
 

--- a/thread_setup.c
+++ b/thread_setup.c
@@ -1,5 +1,5 @@
-//go:build linux && !android
-// +build linux,!android
+//go:build linux
+// +build linux
 
 #include "goopenssl.h"
 #include <pthread.h>


### PR DESCRIPTION
The `!android` build tag was inherited from the `boring` package, which doesn't support Android. OpenSSL does support building on Android, see [docs](https://github.com/openssl/openssl/blob/master/NOTES-ANDROID.md), so we shouldn't be artificially limiting the allowed environments.

This PR is more of a cleanup PR than a feature request, AFAIK no one is using it on Android devices yet.