### PR TITLE
Bump minimum Go version to 1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         openssl-version: [1.0.2, 1.1.0, 1.1.1, 3.0.1, 3.0.9]
     runs-on: ubuntu-20.04
     steps:

--- a/aes.go
+++ b/aes.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/aes_test.go
+++ b/aes_test.go
@@ -6,6 +6,7 @@ package openssl
 import (
 	"bytes"
 	"crypto/cipher"
+	"math"
 	"testing"
 )
 

--- a/aes_test.go
+++ b/aes_test.go
@@ -190,11 +190,7 @@ func TestSealPanic(t *testing.T) {
 		gcm.Seal(nil, make([]byte, gcmStandardNonceSize-1), []byte{0x01, 0x02, 0x03}, nil)
 	})
 	assertPanic(t, func() {
-		// maxInt is implemented as math.MaxInt, but this constant
-		// is only available since go1.17.
-		// TODO: use math.MaxInt once go1.16 is no longer supported.
-		maxInt := int((^uint(0)) >> 1)
-		gcm.Seal(nil, make([]byte, gcmStandardNonceSize), make([]byte, maxInt), nil)
+		gcm.Seal(nil, make([]byte, gcmStandardNonceSize), make([]byte, math.MaxInt), nil)
 	})
 }
 

--- a/aes_test.go
+++ b/aes_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/ec.go
+++ b/ec.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/ecdh.go
+++ b/ecdh.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/ecdh_test.go
+++ b/ecdh_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl_test
 

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl_test
 

--- a/evp.go
+++ b/evp.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/golang-fips/openssl
 
-go 1.18
+go 1.20

--- a/goopenssl.c
+++ b/goopenssl.c
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 #include "goopenssl.h"
 

--- a/hkdf.go
+++ b/hkdf.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/hkdf_test.go
+++ b/hkdf_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl_test
 

--- a/hmac.go
+++ b/hmac.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/init.go
+++ b/init.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/openssl.go
+++ b/openssl.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Package openssl provides access to OpenSSL cryptographic functions.
 package openssl

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl_test
 

--- a/port_evp_md5_sha1.c
+++ b/port_evp_md5_sha1.c
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // The following is a partial backport of crypto/evp/m_md5_sha1.c,
 // commit cbc8a839959418d8a2c2e3ec6bdf394852c9501e on the

--- a/rand.go
+++ b/rand.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/rand_test.go
+++ b/rand_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl_test
 

--- a/rsa.go
+++ b/rsa.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl_test
 

--- a/sha.go
+++ b/sha.go
@@ -154,7 +154,7 @@ func (h *evpHash) Write(p []byte) (int, error) {
 }
 
 func (h *evpHash) WriteString(s string) (int, error) {
-	if len(s) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.StringData(s), C.size_t(len(s))) == 0 {
+	if len(s) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(unsafe.StringData(s)), C.size_t(len(s))) == 0 {
 		panic("openssl: EVP_DigestUpdate failed")
 	}
 	runtime.KeepAlive(h)

--- a/sha.go
+++ b/sha.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl
 

--- a/sha.go
+++ b/sha.go
@@ -154,13 +154,7 @@ func (h *evpHash) Write(p []byte) (int, error) {
 }
 
 func (h *evpHash) WriteString(s string) (int, error) {
-	// TODO: use unsafe.StringData once we drop support
-	// for go1.19 and earlier.
-	hdr := (*struct {
-		Data *byte
-		Len  int
-	})(unsafe.Pointer(&s))
-	if len(s) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.Pointer(hdr.Data), C.size_t(len(s))) == 0 {
+	if len(s) > 0 && C.go_openssl_EVP_DigestUpdate(h.ctx, unsafe.StringData(s), C.size_t(len(s))) == 0 {
 		panic("openssl: EVP_DigestUpdate failed")
 	}
 	runtime.KeepAlive(h)

--- a/sha_test.go
+++ b/sha_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package openssl_test
 

--- a/thread_setup.c
+++ b/thread_setup.c
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 #include "goopenssl.h"
 #include <pthread.h>


### PR DESCRIPTION
This module will be first used in go1.21, so we don't have to keep backwards compatibility with older versions.

Once we start using it, bumping the minimum Go version will be potentially more disruptive, better do it now.