### PR TITLE
Add version suffix to the module name

### DIFF
--- a/bbig/big.go
+++ b/bbig/big.go
@@ -11,7 +11,7 @@ import (
 	"math/big"
 	"unsafe"
 
-	"github.com/golang-fips/openssl"
+	"github.com/golang-fips/openssl/v2"
 )
 
 func Enc(b *big.Int) openssl.BigInt {

--- a/ecdh_test.go
+++ b/ecdh_test.go
@@ -7,7 +7,7 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/golang-fips/openssl"
+	"github.com/golang-fips/openssl/v2"
 )
 
 func TestECDH(t *testing.T) {

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -8,8 +8,8 @@ import (
 	"crypto/elliptic"
 	"testing"
 
-	"github.com/golang-fips/openssl"
-	"github.com/golang-fips/openssl/bbig"
+	"github.com/golang-fips/openssl/v2"
+	"github.com/golang-fips/openssl/v2/bbig"
 )
 
 func testAllCurves(t *testing.T, f func(*testing.T, elliptic.Curve)) {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/golang-fips/openssl
+module github.com/golang-fips/openssl/v2
 
 go 1.20

--- a/hkdf_test.go
+++ b/hkdf_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/golang-fips/openssl"
+	"github.com/golang-fips/openssl/v2"
 )
 
 func TestExtractHKDF(t *testing.T) {

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang-fips/openssl"
+	"github.com/golang-fips/openssl/v2"
 )
 
 // getVersion returns the OpenSSL version to use for testing.

--- a/rand_test.go
+++ b/rand_test.go
@@ -5,7 +5,7 @@ package openssl_test
 import (
 	"testing"
 
-	"github.com/golang-fips/openssl"
+	"github.com/golang-fips/openssl/v2"
 )
 
 func TestRand(t *testing.T) {

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/golang-fips/openssl"
-	"github.com/golang-fips/openssl/bbig"
+	"github.com/golang-fips/openssl/v2"
+	"github.com/golang-fips/openssl/v2/bbig"
 )
 
 func TestRSAKeyGeneration(t *testing.T) {

--- a/sha_test.go
+++ b/sha_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/golang-fips/openssl"
+	"github.com/golang-fips/openssl/v2"
 )
 
 func TestSha(t *testing.T) {


### PR DESCRIPTION
This PR adds the necessary version suffix to the module name.

Found this issue just after cutting `v2.0.0-rc.1` while integrating it into the Microsoft Go fork.

I'll create a new tag. `v2.0.0-rc.1`, after merging this PR.