### PR TITLE
Add !cmd_go_bootstrap tag

### DIFF
--- a/aes.go
+++ b/aes.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 

--- a/ec.go
+++ b/ec.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 

--- a/ecdh.go
+++ b/ecdh.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 

--- a/evp.go
+++ b/evp.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 

--- a/hkdf.go
+++ b/hkdf.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 

--- a/hmac.go
+++ b/hmac.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 

--- a/init.go
+++ b/init.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 

--- a/openssl.go
+++ b/openssl.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 // Package openssl provides access to OpenSSL cryptographic functions.
 package openssl

--- a/rand.go
+++ b/rand.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 

--- a/rsa.go
+++ b/rsa.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 

--- a/sha.go
+++ b/sha.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build linux && !cmd_go_bootstrap
 
 package openssl
 


### PR DESCRIPTION
This is necessary for the Red Hat Go fork as our support for building with openssl is opt-out instead of opt-in, meaning it isn't gated behind a build tag. Without this change `./make.bash` will fail.