### PR TITLE
Support Unix and Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,39 @@ jobs:
         $ok
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+  wintest:
+    runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.20.x]
+        openssl-version: [libcrypto-1_1-x64.dll, libcrypto-3-x64.dll]
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Run Test
+      run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+  mactest:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.20.x]
+        openssl-version: [libcrypto.3.dylib]
+    runs-on: macos-12
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Run Test
+      run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
+      env:
+        GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ This feature does not require any additional configuration, but it only works wi
 
 ## Limitations
 
-OpenSSL is used for a given build only in limited circumstances:
-
-- The platform must be `GOOS=linux`.
+- Only Unix, Unix-like and Windows platforms are supported.
 - The build must set `CGO_ENABLED=1`.
 
 ## Acknowledgements

--- a/aes.go
+++ b/aes.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/aes_test.go
+++ b/aes_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl
 
 import (

--- a/ec.go
+++ b/ec.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/ecdh.go
+++ b/ecdh.go
@@ -101,7 +101,7 @@ func (k *PrivateKeyECDH) PublicKey() (*PublicKeyECDH, error) {
 			return nil, newOpenSSLError("EVP_PKEY_get_octet_string_param")
 		}
 		bytes = C.GoBytes(unsafe.Pointer(cbytes), C.int(n))
-		C.free(unsafe.Pointer(cbytes))
+		cryptoFree(unsafe.Pointer(cbytes))
 	default:
 		panic(errUnsupportedVersion())
 	}

--- a/ecdh.go
+++ b/ecdh.go
@@ -314,8 +314,8 @@ func GenerateKeyECDH(curve string) (*PrivateKeyECDH, []byte, error) {
 	// generating a private ECDH key.
 	bits := C.go_openssl_EVP_PKEY_get_bits(pkey)
 	bytes := make([]byte, (bits+7)/8)
-	if C.go_openssl_BN_bn2binpad(priv, base(bytes), C.int(len(bytes))) == 0 {
-		return nil, nil, newOpenSSLError("BN_bn2binpad")
+	if err := bnToBinPad(priv, bytes); err != nil {
+		return nil, nil, err
 	}
 	k = &PrivateKeyECDH{pkey, curve, true}
 	runtime.SetFinalizer(k, (*PrivateKeyECDH).finalize)

--- a/ecdh.go
+++ b/ecdh.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/ecdh_test.go
+++ b/ecdh_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl_test
 
 import (

--- a/ecdsa.go
+++ b/ecdsa.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl_test
 
 import (

--- a/evp.go
+++ b/evp.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/evp.go
+++ b/evp.go
@@ -197,12 +197,11 @@ func setupEVP(withKey withKeyFunc, padding C.int,
 			}
 		}
 		// ctx takes ownership of label, so malloc a copy for OpenSSL to free.
-		// OpenSSL 1.1.1 and higher does not take ownership of the label if the length is zero,
+		// OpenSSL does not take ownership of the label if the length is zero,
 		// so better avoid the allocation.
 		var clabel *C.uchar
 		if len(label) > 0 {
-			// Go guarantees C.malloc never returns nil.
-			clabel = (*C.uchar)(C.malloc(C.size_t(len(label))))
+			clabel = (*C.uchar)(cryptoMalloc(len(label)))
 			copy((*[1 << 30]byte)(unsafe.Pointer(clabel))[:len(label)], label)
 		}
 		var ret C.int
@@ -212,7 +211,7 @@ func setupEVP(withKey withKeyFunc, padding C.int,
 			ret = C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, C.GO_EVP_PKEY_RSA, -1, C.GO_EVP_PKEY_CTRL_RSA_OAEP_LABEL, C.int(len(label)), unsafe.Pointer(clabel))
 		}
 		if ret != 1 {
-			C.free(unsafe.Pointer(clabel))
+			cryptoFree(unsafe.Pointer(clabel))
 			return nil, newOpenSSLError("EVP_PKEY_CTX_ctrl failed")
 		}
 	case C.GO_RSA_PKCS1_PSS_PADDING:

--- a/goopenssl.c
+++ b/goopenssl.c
@@ -1,8 +1,13 @@
-//go:build linux
+//go:build unix || windows
 
 #include "goopenssl.h"
 
-#include <dlfcn.h> // dlsym
+#ifdef _WIN32
+# include <windows.h>
+# define dlsym (void*)GetProcAddress
+#else
+# include <dlfcn.h> // dlsym
+#endif
 #include <stdio.h> // fprintf
 
 // Approach taken from .Net System.Security.Cryptography.Native

--- a/goopenssl.h
+++ b/goopenssl.h
@@ -116,8 +116,8 @@ go_openssl_EVP_CIPHER_CTX_seal_wrapper(const GO_EVP_CIPHER_CTX_PTR ctx,
                                        const unsigned char *in, int in_len,
                                        const unsigned char *aad, int aad_len)
 {
-    if (in_len == 0) in = "";
-    if (aad_len == 0) aad = "";
+    if (in_len == 0) in = (const unsigned char *)"";
+    if (aad_len == 0) aad = (const unsigned char *)"";
 
     if (go_openssl_EVP_CipherInit_ex(ctx, NULL, NULL, NULL, nonce, GO_AES_ENCRYPT) != 1)
         return 0;
@@ -144,8 +144,8 @@ go_openssl_EVP_CIPHER_CTX_open_wrapper(const GO_EVP_CIPHER_CTX_PTR ctx,
                                        const unsigned char *aad, int aad_len,
                                        const unsigned char *tag)
 {
-    if (in_len == 0) in = "";
-    if (aad_len == 0) aad = "";
+    if (in_len == 0) in = (const unsigned char *)"";
+    if (aad_len == 0) aad = (const unsigned char *)"";
 
     if (go_openssl_EVP_CipherInit_ex(ctx, NULL, NULL, NULL, nonce, GO_AES_DECRYPT) != 1)
         return 0;

--- a/goopenssl.h
+++ b/goopenssl.h
@@ -168,3 +168,16 @@ go_openssl_EVP_CIPHER_CTX_open_wrapper(const GO_EVP_CIPHER_CTX_PTR ctx,
 
     return 1;
 }
+
+// Hand-roll custom wrappers for CRYPTO_malloc and CRYPTO_free which cast the
+// function pointers to the correct signatures for OpenSSL 1.0.2.
+
+static inline void *
+go_openssl_CRYPTO_malloc_legacy102(int num, const char *file, int line) {
+    return ((void *(*)(int, const char *, int))_g_CRYPTO_malloc)(num, file, line);
+}
+
+static inline void
+go_openssl_CRYPTO_free_legacy102(void *str) {
+    ((void (*)(void *))_g_CRYPTO_free)(str);
+}

--- a/hkdf.go
+++ b/hkdf.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/hkdf_test.go
+++ b/hkdf_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl_test
 
 import (

--- a/hmac.go
+++ b/hmac.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl
 
 import (

--- a/init.go
+++ b/init.go
@@ -1,26 +1,23 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 
 // #include "goopenssl.h"
-// #include <dlfcn.h>
 import "C"
 import (
 	"errors"
-	"unsafe"
 )
 
 // opensslInit loads and initialize OpenSSL.
 // If successful, it returns the major and minor OpenSSL version
 // as reported by the OpenSSL API.
 //
-// See Init() for details about version.
-func opensslInit(version string) (major, minor, patch int, err error) {
+// See Init() for details about file.
+func opensslInit(file string) (major, minor, patch int, err error) {
 	// Load the OpenSSL shared library using dlopen.
-	handle := dlopen(version)
-	if handle == nil {
-		errstr := C.GoString(C.dlerror())
-		return 0, 0, 0, errors.New("openssl: can't load libcrypto.so." + version + ": " + errstr)
+	handle, err := dlopen(file)
+	if err != nil {
+		return 0, 0, 0, err
 	}
 
 	// Retrieve the loaded OpenSSL version and check if it is supported.
@@ -63,10 +60,4 @@ func opensslInit(version string) (major, minor, patch int, err error) {
 		}
 	}
 	return major, minor, patch, nil
-}
-
-func dlopen(version string) unsafe.Pointer {
-	cv := C.CString("libcrypto.so." + version)
-	defer C.free(unsafe.Pointer(cv))
-	return C.dlopen(cv, C.RTLD_LAZY|C.RTLD_LOCAL)
 }

--- a/init_unix.go
+++ b/init_unix.go
@@ -1,0 +1,31 @@
+//go:build unix && !cmd_go_bootstrap
+
+package openssl
+
+// #cgo LDFLAGS: -ldl
+// #include <stdlib.h>
+// #include <dlfcn.h>
+import "C"
+import (
+	"errors"
+	"unsafe"
+)
+
+func dlopen(file string) (handle unsafe.Pointer, err error) {
+	cv := C.CString(file)
+	defer C.free(unsafe.Pointer(cv))
+	handle = C.dlopen(cv, C.RTLD_LAZY|C.RTLD_LOCAL)
+	if handle == nil {
+		errstr := C.GoString(C.dlerror())
+		return nil, errors.New("openssl: can't load " + file + ": " + errstr)
+	}
+	return handle, nil
+}
+
+func dlclose(handle unsafe.Pointer) error {
+	if C.dlclose(handle) != 0 {
+		errstr := C.GoString(C.dlerror())
+		return errors.New("openssl: can't close libcrypto: " + errstr)
+	}
+	return nil
+}

--- a/init_windows.go
+++ b/init_windows.go
@@ -1,0 +1,36 @@
+//go:build !cmd_go_bootstrap
+
+package openssl
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+type dlopenError struct {
+	file string
+	err  error
+}
+
+func (e *dlopenError) Error() string {
+	return "openssl: can't load " + e.file + ": " + e.err.Error()
+}
+
+func (e *dlopenError) Unwrap() error {
+	return e.err
+}
+
+func dlopen(file string) (handle unsafe.Pointer, err error) {
+	// As Windows generally does not ship with a system OpenSSL library, let
+	// alone a FIPS 140 certified one, use the default library search order so
+	// that we preferentially load the DLL bundled with the application.
+	h, err := syscall.LoadLibrary(file)
+	if err != nil {
+		return nil, &dlopenError{file: file, err: err}
+	}
+	return unsafe.Pointer(h), nil
+}
+
+func dlclose(handle unsafe.Pointer) error {
+	return syscall.FreeLibrary(syscall.Handle(handle))
+}

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl_test
 
 import (
@@ -16,22 +14,40 @@ import (
 func getVersion() string {
 	v := os.Getenv("GO_OPENSSL_VERSION_OVERRIDE")
 	if v != "" {
+		if runtime.GOOS == "linux" {
+			return "libcrypto.so." + v
+		}
 		return v
 	}
 	// Try to find a supported version of OpenSSL on the system.
 	// This is useful for local testing, where the user may not
 	// have GO_OPENSSL_VERSION_OVERRIDE set.
-	for _, v = range [...]string{"3", "1.1.1", "1.1", "11", "111", "1.0.2", "1.0.0", "10"} {
+	versions := []string{"3", "1.1.1", "1.1", "11", "111", "1.0.2", "1.0.0", "10"}
+	if runtime.GOOS == "windows" {
+		if runtime.GOARCH == "amd64" {
+			versions = []string{"libcrypto-3-x64", "libcrypto-3", "libcrypto-1_1-x64", "libcrypto-1_1", "libeay64", "libeay32"}
+		} else {
+			versions = []string{"libcrypto-3", "libcrypto-1_1", "libeay32"}
+		}
+	}
+	for _, v = range versions {
+		if runtime.GOOS == "windows" {
+			v += ".dll"
+		} else if runtime.GOOS == "darwin" {
+			v = "libcrypto." + v + ".dylib"
+		} else {
+			v = "libcrypto.so." + v
+		}
 		if ok, _ := openssl.CheckVersion(v); ok {
 			return v
 		}
 	}
-	return ""
+	return "libcrypto.so"
 }
 
 func TestMain(m *testing.M) {
 	v := getVersion()
-	fmt.Printf("Using libcrypto.so.%s\n", v)
+	fmt.Printf("Using %s\n", v)
 	err := openssl.Init(v)
 	if err != nil {
 		// An error here could mean that this Linux distro does not have a supported OpenSSL version

--- a/pbkdf2.go
+++ b/pbkdf2.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/pbkdf2_test.go
+++ b/pbkdf2_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl_test
 
 import (

--- a/port_evp_md5_sha1.c
+++ b/port_evp_md5_sha1.c
@@ -1,5 +1,3 @@
-//go:build linux
-
 // The following is a partial backport of crypto/evp/m_md5_sha1.c,
 // commit cbc8a839959418d8a2c2e3ec6bdf394852c9501e on the
 // OpenSSL_1_1_0-stable branch.  The ctrl function has been removed.

--- a/rand.go
+++ b/rand.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/rand_test.go
+++ b/rand_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl_test
 
 import (

--- a/rsa.go
+++ b/rsa.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl_test
 
 import (

--- a/sha.go
+++ b/sha.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/sha_test.go
+++ b/sha_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl_test
 
 import (

--- a/shims.h
+++ b/shims.h
@@ -180,6 +180,11 @@ DEFINEFUNC_LEGACY_1_0(int, CRYPTO_num_locks, (void), ()) \
 DEFINEFUNC_LEGACY_1_0(int, CRYPTO_THREADID_set_callback, (void (*threadid_func) (GO_CRYPTO_THREADID_PTR)), (threadid_func)) \
 DEFINEFUNC_LEGACY_1_0(void, CRYPTO_THREADID_set_numeric, (GO_CRYPTO_THREADID_PTR id, unsigned long val), (id, val)) \
 DEFINEFUNC_LEGACY_1_0(void, CRYPTO_set_locking_callback, (void (*locking_function)(int mode, int n, const char *file, int line)), (locking_function)) \
+/* CRYPTO_malloc argument num changes from int to size_t in OpenSSL 1.1.0, */ \
+/* and CRYPTO_free has file and line arguments added. */ \
+/* Exclude them from headercheck tool when using previous OpenSSL versions. */ \
+/*check:from=1.1.0*/ DEFINEFUNC(void *, CRYPTO_malloc, (size_t num, const char *file, int line), (num, file, line)) \
+/*check:from=1.1.0*/ DEFINEFUNC(void, CRYPTO_free, (void *str, const char *file, int line), (str, file, line)) \
 DEFINEFUNC_LEGACY_1_0(void, OPENSSL_add_all_algorithms_conf, (void), ()) \
 DEFINEFUNC_1_1(int, OPENSSL_init_crypto, (uint64_t ops, const GO_OPENSSL_INIT_SETTINGS_PTR settings), (ops, settings)) \
 DEFINEFUNC_LEGACY_1(int, FIPS_mode, (void), ()) \

--- a/shims.h
+++ b/shims.h
@@ -300,10 +300,11 @@ DEFINEFUNC(void, BN_clear, (GO_BIGNUM_PTR arg0), (arg0)) \
 DEFINEFUNC(void, BN_clear_free, (GO_BIGNUM_PTR arg0), (arg0)) \
 DEFINEFUNC(int, BN_num_bits, (const GO_BIGNUM_PTR arg0), (arg0)) \
 DEFINEFUNC(GO_BIGNUM_PTR, BN_bin2bn, (const unsigned char *arg0, int arg1, GO_BIGNUM_PTR arg2), (arg0, arg1, arg2)) \
-/* bn_lebin2bn, bn_bn2lebinpad and BN_bn2binpad are not exported in any OpenSSL 1.0.2, but they exist. */ \
-/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(GO_BIGNUM_PTR, BN_lebin2bn, bn_lebin2bn, (const unsigned char *s, int len, GO_BIGNUM_PTR ret), (s, len, ret)) \
-/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2lebinpad, bn_bn2lebinpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
-/*check:from=1.1.0*/ DEFINEFUNC_RENAMED_1_1(int, BN_bn2binpad, bn_bn2binpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
+DEFINEFUNC_LEGACY_1_0(int, BN_bn2bin, (const GO_BIGNUM_PTR a, unsigned char *to), (a, to)) \
+DEFINEFUNC_LEGACY_1_0(GO_BIGNUM_PTR, bn_expand2, (GO_BIGNUM_PTR a, int n), (a, n)) \
+DEFINEFUNC_1_1(GO_BIGNUM_PTR, BN_lebin2bn, (const unsigned char *s, int len, GO_BIGNUM_PTR ret), (s, len, ret)) \
+DEFINEFUNC_1_1(int, BN_bn2lebinpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
+DEFINEFUNC_1_1(int, BN_bn2binpad, (const GO_BIGNUM_PTR a, unsigned char *to, int tolen), (a, to, tolen)) \
 DEFINEFUNC_LEGACY_1(int, EC_KEY_set_public_key_affine_coordinates, (GO_EC_KEY_PTR key, GO_BIGNUM_PTR x, GO_BIGNUM_PTR y), (key, x, y)) \
 DEFINEFUNC_LEGACY_1(int, EC_KEY_set_public_key, (GO_EC_KEY_PTR key, const GO_EC_POINT_PTR pub), (key, pub)) \
 DEFINEFUNC_LEGACY_1(void, EC_KEY_free, (GO_EC_KEY_PTR arg0), (arg0)) \

--- a/thread_setup_unix.c
+++ b/thread_setup_unix.c
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build unix
 
 #include "goopenssl.h"
 #include <pthread.h>

--- a/thread_setup_windows.c
+++ b/thread_setup_windows.c
@@ -1,0 +1,33 @@
+//go:build windows
+
+#include "goopenssl.h"
+
+#include <stdlib.h>
+#include <windows.h>
+
+#define CRYPTO_LOCK      0x01
+
+/* This array will store all of the mutexes available to OpenSSL. */
+static HANDLE *mutex_buf = NULL;
+
+static void locking_function(int mode, int n, const char *file, int line)
+{
+    if (mode & CRYPTO_LOCK)
+        WaitForSingleObject(mutex_buf[n], INFINITE);
+    else
+        ReleaseMutex(mutex_buf[n]);
+}
+
+int go_openssl_thread_setup(void)
+{
+    mutex_buf = malloc(go_openssl_CRYPTO_num_locks()*sizeof(HANDLE));
+    if (!mutex_buf)
+        return 0;
+    int i;
+    for (i = 0; i < go_openssl_CRYPTO_num_locks(); i++)
+        mutex_buf[i] = CreateMutex(NULL, FALSE, NULL);
+    go_openssl_CRYPTO_set_locking_callback(locking_function);
+    // go_openssl_CRYPTO_set_id_callback is not needed on Windows
+    // as OpenSSL uses GetCurrentThreadId() by default.
+    return 1;
+}

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -1,4 +1,4 @@
-//go:build linux && !cmd_go_bootstrap
+//go:build !cmd_go_bootstrap
 
 package openssl
 

--- a/tls1prf_test.go
+++ b/tls1prf_test.go
@@ -1,5 +1,3 @@
-//go:build linux
-
 package openssl_test
 
 import (


### PR DESCRIPTION
- Carries #48 

Add support for any target which satisfies the build constraint `cgo && (windows || unix)`.

The Linux limitation is somewhat artificial. The only platform-specific parts of the module are dynamic linking and loading of the OpenSSL library, and the OpenSSL 1.0.2 threading callbacks. The implementations of both are already portable to any Unix-like OS as `dlfcn.h` and pthreads are part of the POSIX standard. The only issue with the dynamic loader implementation is that it assumes the naming convention for the library shared object is `"libcrypto.so.<version>"` which limits support for darwin and other platforms which follow a different convention. Change `openssl.Init()` and `openssl.CheckVersion()` to take the library file name as its argument to make the bindings agnostic to the target platform's library file naming convention. Widen the build constraints to allow the module with the `dlopen()`-based loader to be built on any OS which satisfies the "unix" Go build constraint.

Windows's dynamic library loader API is shaped very similarly to POSIX's, aside from the function names. Add support for Windows by adding Windows implementations for linking and loading the OpenSSL library, and the threading callbacks.

-----

Tested on Windows Server 2022 with OpenSSL 1.0.2zh-fips (Safelogic Cryptocomply), and macOS Ventura 13.4 (x86_64) with Homebrew OpenSSL 1.1.1 and OpenSSL 3.0.8.