### PR TITLE
Generalize checking if a crypto.Hash is supported

### DIFF
--- a/evp.go
+++ b/evp.go
@@ -60,6 +60,9 @@ func cryptoHashToMD(ch crypto.Hash) (md C.GO_EVP_MD_PTR) {
 		}
 		cacheMD.Store(ch, md)
 	}()
+	// SupportsHash returns false for MD5 and MD5SHA1 because we don't
+	// provide a hash.Hash implementation for them. Yet, they can
+	// still be used when signing/verifying with an RSA key.
 	switch ch {
 	case crypto.MD5:
 		return C.go_openssl_EVP_md5()
@@ -69,6 +72,11 @@ func cryptoHashToMD(ch crypto.Hash) (md C.GO_EVP_MD_PTR) {
 		} else {
 			return C.go_openssl_EVP_md5_sha1()
 		}
+	}
+	if !SupportsHash(ch) {
+		return nil
+	}
+	switch ch {
 	case crypto.SHA1:
 		return C.go_openssl_EVP_sha1()
 	case crypto.SHA224:
@@ -80,24 +88,12 @@ func cryptoHashToMD(ch crypto.Hash) (md C.GO_EVP_MD_PTR) {
 	case crypto.SHA512:
 		return C.go_openssl_EVP_sha512()
 	case crypto.SHA3_224:
-		if !SupportsSHA3() {
-			return nil
-		}
 		return C.go_openssl_EVP_sha3_224()
 	case crypto.SHA3_256:
-		if !SupportsSHA3() {
-			return nil
-		}
 		return C.go_openssl_EVP_sha3_256()
 	case crypto.SHA3_384:
-		if !SupportsSHA3() {
-			return nil
-		}
 		return C.go_openssl_EVP_sha3_384()
 	case crypto.SHA3_512:
-		if !SupportsSHA3() {
-			return nil
-		}
 		return C.go_openssl_EVP_sha3_512()
 	}
 	return nil

--- a/sha.go
+++ b/sha.go
@@ -63,7 +63,7 @@ func SHA512(p []byte) (sum [64]byte) {
 	return
 }
 
-// SupportsHash returns true if h is supported.
+// SupportsHash returns true if a hash.Hash implementation is supported for h.
 func SupportsHash(h crypto.Hash) bool {
 	switch h {
 	case crypto.SHA1, crypto.SHA224, crypto.SHA256, crypto.SHA384, crypto.SHA512:

--- a/sha.go
+++ b/sha.go
@@ -63,11 +63,17 @@ func SHA512(p []byte) (sum [64]byte) {
 	return
 }
 
-// Same as SupportsHKDF, as in v1.1.1+
-func SupportsSHA3() bool {
-	return vMajor > 1 ||
-		(vMajor >= 1 && vMinor > 1) ||
-		(vMajor >= 1 && vMinor >= 1 && vPatch >= 1)
+// SupportsHash returns true if h is supported.
+func SupportsHash(h crypto.Hash) bool {
+	switch h {
+	case crypto.SHA1, crypto.SHA224, crypto.SHA256, crypto.SHA384, crypto.SHA512:
+		return true
+	case crypto.SHA3_224, crypto.SHA3_256, crypto.SHA3_384, crypto.SHA3_512:
+		return vMajor > 1 ||
+			(vMajor >= 1 && vMinor > 1) ||
+			(vMajor >= 1 && vMinor >= 1 && vPatch >= 1)
+	}
+	return false
 }
 
 func SHA3_224(p []byte) (sum [28]byte) {


### PR DESCRIPTION
This PR removes `SupportsSHA3()` and replaces it with `SupportsHash(crypto.Hash)`, which is more future-proof and supports fine-grained hash queries.