### PR TITLE
SupportsTLS1PRF should report true for OpenSSL 1.x

### DIFF
--- a/tls1prf.go
+++ b/tls1prf.go
@@ -13,7 +13,7 @@ import (
 
 func SupportsTLS1PRF() bool {
 	return vMajor > 1 ||
-		(vMajor >= 1 && vMinor > 1)
+		(vMajor >= 1 && vMinor >= 1)
 }
 
 func TLS1PRF(secret, label, seed []byte, keyLen int, h func() hash.Hash) ([]byte, error) {

--- a/tls1prf_test.go
+++ b/tls1prf_test.go
@@ -147,7 +147,7 @@ var tls1prfTests = []tls1prfTest{
 
 func TestTLS1PRF(t *testing.T) {
 	if !openssl.SupportsTLS1PRF() {
-		t.Skip("TLS 1.2 PRF is not supported")
+		t.Skip("TLS PRF is not supported")
 	}
 	for _, tt := range tls1prfTests {
 		tt := tt


### PR DESCRIPTION
`SupportsTLS1PRF` doesn't return true for 1.1.0 nor 1.1.1, and it should.