### PR TITLE
Add noescape and nocallback directive to EVP_PKEY_derive

### DIFF
--- a/cgo_go122.go
+++ b/cgo_go122.go
@@ -1,0 +1,13 @@
+//go:build go1.22 && !cmd_go_bootstrap
+
+package openssl
+
+/*
+// The following noescape and nocallback directives are used to
+// prevent the Go compiler from allocating function parameters on the
+// heap. This is just a performance optimization. Only add those
+// functions that are known to allocate.
+#cgo noescape go_openssl_EVP_PKEY_derive
+#cgo nocallback go_openssl_EVP_PKEY_derive
+*/
+import "C"

--- a/ecdh_test.go
+++ b/ecdh_test.go
@@ -146,3 +146,28 @@ func hexDecode(t *testing.T, s string) []byte {
 	}
 	return b
 }
+
+func BenchmarkECDH(b *testing.B) {
+	const curve = "P-256"
+	aliceKey, _, err := openssl.GenerateKeyECDH(curve)
+	if err != nil {
+		b.Fatal(err)
+	}
+	bobKey, _, err := openssl.GenerateKeyECDH(curve)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	alicePubKey, err := aliceKey.PublicKey()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := openssl.ECDH(bobKey, alicePubKey)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
`noescape` and `nocallback` are new go1.22 cgo directives that helps the Go compiler take better decisions. See https://github.com/golang/go/issues/56378 for more context.

In this PR I've tagged [EVP_PKEY_derive](https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_derive.html) with both directives, which allows the `keylen` parameter to stay on the stack. `EVP_PKEY_derive` is currently used in ECDH, HKDF and TLS1PRF, so they will all automatically benefit from this optimization.

Benchmark prove for ECDH:

```
goos: windows
goarch: amd64
pkg: github.com/golang-fips/openssl/v2
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
        │   old.txt    │            new.txt             │
        │    sec/op    │    sec/op     vs base          │
ECDH-12   53.01µ ± 12%   53.24µ ± 11%  ~ (p=0.853 n=10)

        │  old.txt   │              new.txt               │
        │    B/op    │    B/op     vs base                │
ECDH-12   40.00 ± 0%   32.00 ± 0%  -20.00% (p=0.000 n=10)

        │  old.txt   │              new.txt               │
        │ allocs/op  │ allocs/op   vs base                │
ECDH-12   2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
```