### PR TITLE
Fix RSA OAEP failure when given empty label with OpenSSL 3

### DIFF
--- a/rsa_test.go
+++ b/rsa_test.go
@@ -57,6 +57,29 @@ func TestEncryptDecryptOAEP(t *testing.T) {
 	}
 }
 
+func TestEncryptDecryptOAEP_EmptyLabel(t *testing.T) {
+	sha256 := openssl.NewSHA256()
+	msg := []byte("hi!")
+	label := []byte("")
+	priv, pub := newRSAKey(t, 2048)
+	enc, err := openssl.EncryptRSAOAEP(sha256, nil, pub, msg, label)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec, err := openssl.DecryptRSAOAEP(sha256, nil, priv, enc, label)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(dec, msg) {
+		t.Errorf("got:%x want:%x", dec, msg)
+	}
+	sha1 := openssl.NewSHA1()
+	_, err = openssl.DecryptRSAOAEP(sha1, nil, priv, enc, label)
+	if err == nil {
+		t.Error("decrypt failure expected due to hash mismatch")
+	}
+}
+
 func TestEncryptDecryptOAEP_WithMGF1Hash(t *testing.T) {
 	sha1 := openssl.NewSHA1()
 	sha256 := openssl.NewSHA256()


### PR DESCRIPTION
Found this while running x/crypto `internal/wycheproof` tests using the OpenSSL backend.

* The bug is already reported to OpenSSL:  
  https://github.com/openssl/openssl/issues/21288.

The [doc](https://www.openssl.org/docs/man3.1/man3/EVP_PKEY_CTX_set0_rsa_oaep_label.html) is pretty clear that what we were doing should work:

> EVP_PKEY_CTX_set0_rsa_oaep_label() sets the RSA OAEP label to binary data label and its length in bytes to len. If label is NULL or len is 0, the label is cleared.

Also fixes the error message to match the function name.