### PR TITLE
Read signed message through io.Reader in HashSign/HashVerify

### DIFF
--- a/ecdsa.go
+++ b/ecdsa.go
@@ -7,6 +7,7 @@ import "C"
 import (
 	"crypto"
 	"errors"
+	"io"
 	"runtime"
 )
 
@@ -109,7 +110,7 @@ func SignMarshalECDSA(priv *PrivateKeyECDSA, hash []byte) ([]byte, error) {
 	return evpSign(priv.withKey, 0, 0, 0, hash)
 }
 
-func HashSignECDSA(priv *PrivateKeyECDSA, h crypto.Hash, msg []byte) ([]byte, error) {
+func HashSignECDSA(priv *PrivateKeyECDSA, h crypto.Hash, msg io.Reader) ([]byte, error) {
 	return evpHashSign(priv.withKey, h, msg)
 }
 
@@ -117,7 +118,7 @@ func VerifyECDSA(pub *PublicKeyECDSA, hash []byte, sig []byte) bool {
 	return evpVerify(pub.withKey, 0, 0, 0, sig, hash) == nil
 }
 
-func HashVerifyECDSA(pub *PublicKeyECDSA, h crypto.Hash, msg, sig []byte) bool {
+func HashVerifyECDSA(pub *PublicKeyECDSA, h crypto.Hash, msg io.Reader, sig []byte) bool {
 	return evpHashVerify(pub.withKey, h, msg, sig) == nil
 }
 

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -1,6 +1,7 @@
 package openssl_test
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -74,15 +75,15 @@ func testECDSASignAndVerify(t *testing.T, c elliptic.Curve) {
 	if openssl.VerifyECDSA(pub, hashed[:], signed) {
 		t.Errorf("Verify succeeded despite intentionally invalid hash!")
 	}
-	signed, err = openssl.HashSignECDSA(priv, crypto.SHA256, msg)
+	signed, err = openssl.HashSignECDSA(priv, crypto.SHA256, bytes.NewReader(msg))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !openssl.HashVerifyECDSA(pub, crypto.SHA256, msg, signed) {
+	if !openssl.HashVerifyECDSA(pub, crypto.SHA256, bytes.NewReader(msg), signed) {
 		t.Errorf("Verify failed")
 	}
 	signed[0] ^= 0xff
-	if openssl.HashVerifyECDSA(pub, crypto.SHA256, msg, signed) {
+	if openssl.HashVerifyECDSA(pub, crypto.SHA256, bytes.NewReader(msg), signed) {
 		t.Errorf("Verify failed")
 	}
 }

--- a/rsa.go
+++ b/rsa.go
@@ -9,6 +9,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"hash"
+	"io"
 	"runtime"
 	"unsafe"
 )
@@ -289,7 +290,7 @@ func SignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, hashed []byte) ([]byte,
 	return evpSign(priv.withKey, C.GO_RSA_PKCS1_PADDING, 0, h, hashed)
 }
 
-func HashSignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, msg []byte) ([]byte, error) {
+func HashSignRSAPKCS1v15(priv *PrivateKeyRSA, h crypto.Hash, msg io.Reader) ([]byte, error) {
 	return evpHashSign(priv.withKey, h, msg)
 }
 
@@ -306,7 +307,7 @@ func VerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, hashed, sig []byte) err
 	return evpVerify(pub.withKey, C.GO_RSA_PKCS1_PADDING, 0, h, sig, hashed)
 }
 
-func HashVerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, msg, sig []byte) error {
+func HashVerifyRSAPKCS1v15(pub *PublicKeyRSA, h crypto.Hash, msg io.Reader, sig []byte) error {
 	return evpHashVerify(pub.withKey, h, msg, sig)
 }
 

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -130,7 +130,7 @@ func TestSignVerifyPKCS1v15(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	signed2, err := openssl.HashSignRSAPKCS1v15(priv, crypto.SHA256, msg)
+	signed2, err := openssl.HashSignRSAPKCS1v15(priv, crypto.SHA256, bytes.NewReader(msg))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -141,7 +141,7 @@ func TestSignVerifyPKCS1v15(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = openssl.HashVerifyRSAPKCS1v15(pub, crypto.SHA256, msg, signed2)
+	err = openssl.HashVerifyRSAPKCS1v15(pub, crypto.SHA256, bytes.NewReader(msg), signed2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/shims.h
+++ b/shims.h
@@ -355,4 +355,5 @@ DEFINEFUNC(int, PKCS5_PBKDF2_HMAC, (const char *pass, int passlen, const unsigne
 DEFINEFUNC_3_0(int, EVP_PKEY_CTX_set_tls1_prf_md, (GO_EVP_PKEY_CTX_PTR arg0, const GO_EVP_MD_PTR arg1), (arg0, arg1)) \
 DEFINEFUNC_3_0(int, EVP_PKEY_CTX_set1_tls1_prf_secret, (GO_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2), (arg0, arg1, arg2)) \
 DEFINEFUNC_3_0(int, EVP_PKEY_CTX_add1_tls1_prf_seed, (GO_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2), (arg0, arg1, arg2)) \
+DEFINEFUNC_RENAMED_3_0(int, EVP_MD_get_block_size, EVP_MD_block_size, (const GO_EVP_MD_PTR md), (md)) \
 


### PR DESCRIPTION
When signed message is large, passing it through a byte array would cost memory; this switches to using io.Reader to avoid that.

Using `io.Reader` in the function signatures could also help diversify those HashSign/HashVerify from Sign/Verify, through a separate interface, alongside the `crypto.Signer` interface.