### PR TITLE
Reconcile AES and DES error messages with upstream

### DIFF
--- a/aes.go
+++ b/aes.go
@@ -56,11 +56,17 @@ func (c *aesCipher) BlockSize() int {
 }
 
 func (c *aesCipher) Encrypt(dst, src []byte) {
-	c.encrypt(dst, src)
+	if err := c.encrypt(dst, src); err != nil {
+		// Upstream expects that the panic message starts with "crypto/aes: ".
+		panic("crypto/aes: " + err.Error())
+	}
 }
 
 func (c *aesCipher) Decrypt(dst, src []byte) {
-	c.decrypt(dst, src)
+	if err := c.decrypt(dst, src); err != nil {
+		// Upstream expects that the panic message starts with "crypto/aes: ".
+		panic("crypto/aes: " + err.Error())
+	}
 }
 
 func (c *aesCipher) NewCBCEncrypter(iv []byte) cipher.BlockMode {

--- a/aes_test.go
+++ b/aes_test.go
@@ -9,6 +9,31 @@ import (
 	"github.com/golang-fips/openssl/v2"
 )
 
+func TestAESShortBlocks(t *testing.T) {
+	bytes := func(n int) []byte { return make([]byte, n) }
+
+	c, _ := openssl.NewAESCipher(bytes(16))
+
+	mustPanic(t, "crypto/aes: input not full block", func() { c.Encrypt(bytes(1), bytes(1)) })
+	mustPanic(t, "crypto/aes: input not full block", func() { c.Decrypt(bytes(1), bytes(1)) })
+	mustPanic(t, "crypto/aes: input not full block", func() { c.Encrypt(bytes(100), bytes(1)) })
+	mustPanic(t, "crypto/aes: input not full block", func() { c.Decrypt(bytes(100), bytes(1)) })
+	mustPanic(t, "crypto/aes: output not full block", func() { c.Encrypt(bytes(1), bytes(100)) })
+	mustPanic(t, "crypto/aes: output not full block", func() { c.Decrypt(bytes(1), bytes(100)) })
+}
+
+func mustPanic(t *testing.T, msg string, f func()) {
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Errorf("function did not panic, wanted %q", msg)
+		} else if err != msg {
+			t.Errorf("got panic %v, wanted %q", err, msg)
+		}
+	}()
+	f()
+}
+
 func TestNewGCMNonce(t *testing.T) {
 	key := []byte("D249BF6DEC97B1EBD69BC4D6B3A3C49D")
 	ci, err := openssl.NewAESCipher(key)

--- a/des.go
+++ b/des.go
@@ -75,11 +75,17 @@ func (c *desCipher) BlockSize() int {
 }
 
 func (c *desCipher) Encrypt(dst, src []byte) {
-	c.encrypt(dst, src)
+	if err := c.encrypt(dst, src); err != nil {
+		// Upstream expects that the panic message starts with "crypto/des: ".
+		panic("crypto/des: " + err.Error())
+	}
 }
 
 func (c *desCipher) Decrypt(dst, src []byte) {
-	c.decrypt(dst, src)
+	if err := c.decrypt(dst, src); err != nil {
+		// Upstream expects that the panic message starts with "crypto/des: ".
+		panic("crypto/des: " + err.Error())
+	}
 }
 
 func (c *desCipher) NewCBCEncrypter(iv []byte) cipher.BlockMode {


### PR DESCRIPTION
`crypto/aes` and `crypto/des` expects that `Encrypt` and `Decrypt` error messages start with `crypto/aes: ` and `crypto/des`, there is even a test for that: https://github.com/golang/go/blob/ace1494d9235be94f1325ab6e45105a446b3224c/src/crypto/aes/aes_test.go#L322-L333

We recently changed those methods to return the more generic prefix `crypto/cipher: `, which broke the upstream test.

This PR fixes that by using the appropriate error prefix.