### PR TITLE
Update GenerateKeyEd25519 to only generate a private key

### DIFF
--- a/ed25519.go
+++ b/ed25519.go
@@ -85,25 +85,27 @@ func (k *PrivateKeyEd25519) Bytes() ([]byte, error) {
 	return priv, nil
 }
 
-// GenerateKeyEd25519 generates a public/private key pair.
-func GenerateKeyEd25519() (*PublicKeyEd25519, *PrivateKeyEd25519, error) {
-	pkeyPriv, err := generateEVPPKey(C.GO_EVP_PKEY_ED25519, 0, "")
-	if err != nil {
-		return nil, nil, err
-	}
+func (k *PrivateKeyEd25519) Public() (*PublicKeyEd25519, error) {
 	pub := make([]byte, publicKeySizeEd25519)
-	if err := extractPKEYPubEd25519(pkeyPriv, pub); err != nil {
-		C.go_openssl_EVP_PKEY_free(pkeyPriv)
-		return nil, nil, err
+	if err := extractPKEYPubEd25519(k._pkey, pub); err != nil {
+		return nil, err
 	}
 	pubk, err := NewPublicKeyEd25119(pub)
 	if err != nil {
-		C.go_openssl_EVP_PKEY_free(pkeyPriv)
-		return nil, nil, err
+		return nil, err
 	}
-	privk := &PrivateKeyEd25519{_pkey: pkeyPriv}
-	runtime.SetFinalizer(privk, (*PrivateKeyEd25519).finalize)
-	return pubk, privk, nil
+	return pubk, nil
+}
+
+// GenerateKeyEd25519 generates a private key.
+func GenerateKeyEd25519() (*PrivateKeyEd25519, error) {
+	pkeyPriv, err := generateEVPPKey(C.GO_EVP_PKEY_ED25519, 0, "")
+	if err != nil {
+		return nil, err
+	}
+	priv := &PrivateKeyEd25519{_pkey: pkeyPriv}
+	runtime.SetFinalizer(priv, (*PrivateKeyEd25519).finalize)
+	return priv, nil
 }
 
 func NewPrivateKeyEd25119(priv []byte) (*PrivateKeyEd25519, error) {

--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -31,7 +31,11 @@ func TestEd25519SignVerify(t *testing.T) {
 	if !openssl.SupportsEd25519() {
 		t.Skip("Ed25519 not supported")
 	}
-	public, private, err := openssl.GenerateKeyEd25519()
+	private, err := openssl.GenerateKeyEd25519()
+	if err != nil {
+		t.Fatal(err)
+	}
+	public, err := private.Public()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +97,7 @@ func BenchmarkEd25519GenerateKey(b *testing.B) {
 		b.Skip("Ed25519 not supported")
 	}
 	for i := 0; i < b.N; i++ {
-		_, _, err := openssl.GenerateKeyEd25519()
+		_, err := openssl.GenerateKeyEd25519()
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -117,7 +121,7 @@ func BenchmarkEd25519Signing(b *testing.B) {
 	if !openssl.SupportsEd25519() {
 		b.Skip("Ed25519 not supported")
 	}
-	_, priv, err := openssl.GenerateKeyEd25519()
+	priv, err := openssl.GenerateKeyEd25519()
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -132,7 +136,11 @@ func BenchmarkEd25519Verification(b *testing.B) {
 	if !openssl.SupportsEd25519() {
 		b.Skip("Ed25519 not supported")
 	}
-	pub, priv, err := openssl.GenerateKeyEd25519()
+	priv, err := openssl.GenerateKeyEd25519()
+	if err != nil {
+		b.Fatal(err)
+	}
+	pub, err := priv.Public()
 	if err != nil {
 		b.Fatal(err)
 	}


### PR DESCRIPTION
While integrating Ed25519 into the standard library I noticed that it is not necessary for `GenerateKeyEd25519` to return the public key, as it can already be derived from the private key.

Doing so can help reduces allocations and cgo calls in [ed25519.GenerateKey](https://pkg.go.dev/crypto/ed25519#GenerateKey), depending on how one decides to implement it.

```cmd
goos: windows
goarch: amd64
pkg: github.com/golang-fips/openssl/v2
cpu: Intel(R) Core(TM) i7-10850H CPU @ 2.70GHz
                      │   old.txt    │               new.txt               │
                      │    sec/op    │   sec/op     vs base                │
Ed25519GenerateKey-12   47.48µ ± 18%   35.97µ ± 7%  -24.25% (p=0.000 n=10)

                      │  old.txt   │              new.txt               │
                      │    B/op    │    B/op     vs base                │
Ed25519GenerateKey-12   56.00 ± 0%   16.00 ± 0%  -71.43% (p=0.000 n=10)

                      │  old.txt   │              new.txt               │
                      │ allocs/op  │ allocs/op   vs base                │
Ed25519GenerateKey-12   4.000 ± 0%   2.000 ± 0%  -50.00% (p=0.000 n=10)
```