### PR TITLE
v1: Port HMAC to using EVP_DigestSign if available

### DIFF
--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -805,8 +805,8 @@ DEFINEFUNC(GO_RSA *, EVP_PKEY_get1_RSA, (GO_EVP_PKEY * arg0), (arg0))
 DEFINEFUNC(int, EVP_PKEY_set1_RSA, (GO_EVP_PKEY * arg0, GO_RSA *arg1), (arg0, arg1))
 DEFINEFUNC(GO_EC_KEY *, EVP_PKEY_get1_EC_KEY, (GO_EVP_PKEY * arg0), (arg0))
 DEFINEFUNC(int, EVP_PKEY_set1_EC_KEY, (GO_EVP_PKEY * arg0, GO_EC_KEY *arg1), (arg0, arg1))
-DEFINEFUNC(const GO_EC_KEY *, EVP_PKEY_get0_EC_KEY, (const GO_EVP_PKEY *pkey), (pkey))
 GO_EVP_PKEY *_goboringcrypto_EVP_PKEY_ref(GO_EVP_PKEY *pkey);
+const GO_EC_KEY *_goboringcrypto_EVP_PKEY_get0_EC_KEY(const GO_EVP_PKEY *pkey);
 
 DEFINEFUNC(int, EVP_PKEY_verify,
 	(EVP_PKEY_CTX *ctx, const unsigned char *sig, unsigned int siglen, const unsigned char *tbs, size_t tbslen),

--- a/openssl/goopenssl.h
+++ b/openssl/goopenssl.h
@@ -255,70 +255,16 @@ _goboringcrypto_EVP_md5_sha1(void) {
 #endif
 }
 
-#include <openssl/hmac.h>
+typedef struct go_hmac_ctx GO_HMAC_CTX;
 
-typedef HMAC_CTX GO_HMAC_CTX;
-
-DEFINEFUNC(int, HMAC_Init_ex,
-		   (GO_HMAC_CTX * arg0, const void *arg1, int arg2, const GO_EVP_MD *arg3, ENGINE *arg4),
-		   (arg0, arg1, arg2, arg3, arg4))
-DEFINEFUNC(int, HMAC_Update, (GO_HMAC_CTX * arg0, const uint8_t *arg1, size_t arg2), (arg0, arg1, arg2))
-DEFINEFUNC(int, HMAC_Final, (GO_HMAC_CTX * arg0, uint8_t *arg1, unsigned int *arg2), (arg0, arg1, arg2))
-DEFINEFUNC(size_t, HMAC_CTX_copy, (GO_HMAC_CTX *dest, GO_HMAC_CTX *src), (dest, src))
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-DEFINEFUNCINTERNAL(void, HMAC_CTX_cleanup, (GO_HMAC_CTX * arg0), (arg0))
-static inline void
-_goboringcrypto_HMAC_CTX_free(HMAC_CTX *ctx) {
-   if (ctx != NULL) {
-       _goboringcrypto_internal_HMAC_CTX_cleanup(ctx);
-       free(ctx);
-   }
-}
-#else
-DEFINEFUNC(void, HMAC_CTX_free, (GO_HMAC_CTX * arg0), (arg0))
-#endif
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-static inline size_t
-_goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
-	return _goboringcrypto_EVP_MD_get_size(arg0->md);
-}
-#else
-DEFINEFUNCINTERNAL(const EVP_MD*, HMAC_CTX_get_md, (const GO_HMAC_CTX* ctx), (ctx))
-static inline size_t
-_goboringcrypto_HMAC_size(const GO_HMAC_CTX* arg0) {
-	const EVP_MD* md;
-	md = _goboringcrypto_internal_HMAC_CTX_get_md(arg0);
-	return _goboringcrypto_EVP_MD_get_size(md);
-}
-#endif
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-DEFINEFUNCINTERNAL(void, HMAC_CTX_init, (GO_HMAC_CTX * arg0), (arg0))
-static inline GO_HMAC_CTX*
-_goboringcrypto_HMAC_CTX_new(void) {
-	GO_HMAC_CTX* ctx = malloc(sizeof(GO_HMAC_CTX));
-	if (ctx != NULL)
-		_goboringcrypto_internal_HMAC_CTX_init(ctx);
-	return ctx;
-}
-#else
-DEFINEFUNC(GO_HMAC_CTX*, HMAC_CTX_new, (void), ())
-#endif
-
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-static inline int
-_goboringcrypto_HMAC_CTX_reset(GO_HMAC_CTX* ctx) {
-	_goboringcrypto_internal_HMAC_CTX_cleanup(ctx);
-	_goboringcrypto_internal_HMAC_CTX_init(ctx);
-	return 0;
-}
-#else
-DEFINEFUNC(int, HMAC_CTX_reset, (GO_HMAC_CTX * arg0), (arg0))
-#endif
-
-int _goboringcrypto_HMAC_CTX_copy_ex(GO_HMAC_CTX *dest, const GO_HMAC_CTX *src);
+GO_HMAC_CTX *_goboringcrypto_HMAC_CTX_new(const unsigned char *key, int keylen,
+					  const EVP_MD *md);
+int _goboringcrypto_HMAC_Update(GO_HMAC_CTX *ctx,
+				const unsigned char *data, size_t len);
+int _goboringcrypto_HMAC_CTX_reset(GO_HMAC_CTX *ctx);
+void _goboringcrypto_HMAC_CTX_free(GO_HMAC_CTX *ctx);
+int _goboringcrypto_HMAC_Final(GO_HMAC_CTX *ctx,
+			       unsigned char *md, unsigned int *len);
 
 #include <openssl/evp.h>
 #include <openssl/aes.h>

--- a/openssl/hmac_test.go
+++ b/openssl/hmac_test.go
@@ -1,17 +1,89 @@
 package openssl
 
 import (
+	"bytes"
+	"hash"
 	"testing"
 )
 
-// Just tests that we can create an HMAC instance.
-// Previously would cause panic because of incorrect
-// stack allocation of opaque OpenSSL type.
-func TestNewHMAC(t *testing.T) {
-	if !Enabled() {
-		t.Skip("boringcrypto: skipping test, FIPS not enabled")
+func TestHMAC(t *testing.T) {
+	var tests = []struct {
+		name string
+		fn   func() hash.Hash
+	}{
+		{"sha1", NewSHA1},
+		{"sha224", NewSHA224},
+		{"sha256", NewSHA256},
+		{"sha384", NewSHA384},
+		{"sha512", NewSHA512},
 	}
-	mac := NewHMAC(NewSHA256, nil)
-	mac.Write([]byte("foo"))
-	t.Logf("%x\n", mac.Sum(nil))
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := NewHMAC(tt.fn, nil)
+			h.Write([]byte("hello"))
+			sumHello := h.Sum(nil)
+
+			h = NewHMAC(tt.fn, nil)
+			h.Write([]byte("hello world"))
+			sumHelloWorld := h.Sum(nil)
+
+			// Test that Sum has no effect on future Sum or Write operations.
+			// This is a bit unusual as far as usage, but it's allowed
+			// by the definition of Go hash.Hash, and some clients expect it to work.
+			h = NewHMAC(tt.fn, nil)
+			h.Write([]byte("hello"))
+			if sum := h.Sum(nil); !bytes.Equal(sum, sumHello) {
+				t.Fatalf("1st Sum after hello = %x, want %x", sum, sumHello)
+			}
+			if sum := h.Sum(nil); !bytes.Equal(sum, sumHello) {
+				t.Fatalf("2nd Sum after hello = %x, want %x", sum, sumHello)
+			}
+
+			h.Write([]byte(" world"))
+			if sum := h.Sum(nil); !bytes.Equal(sum, sumHelloWorld) {
+				t.Fatalf("1st Sum after hello world = %x, want %x", sum, sumHelloWorld)
+			}
+			if sum := h.Sum(nil); !bytes.Equal(sum, sumHelloWorld) {
+				t.Fatalf("2nd Sum after hello world = %x, want %x", sum, sumHelloWorld)
+			}
+
+			h.Reset()
+			h.Write([]byte("hello"))
+			if sum := h.Sum(nil); !bytes.Equal(sum, sumHello) {
+				t.Fatalf("Sum after Reset + hello = %x, want %x", sum, sumHello)
+			}
+		})
+	}
+}
+
+func BenchmarkHMACSHA256_32(b *testing.B) {
+	b.StopTimer()
+	key := make([]byte, 32)
+	buf := make([]byte, 32)
+	h := NewHMAC(NewSHA256, key)
+	b.SetBytes(int64(len(buf)))
+	b.StartTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		h.Write(buf)
+		mac := h.Sum(nil)
+		h.Reset()
+		buf[0] = mac[0]
+	}
+}
+
+func BenchmarkHMACNewWriteSum(b *testing.B) {
+	b.StopTimer()
+	buf := make([]byte, 32)
+	b.SetBytes(int64(len(buf)))
+	b.StartTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		h := NewHMAC(NewSHA256, make([]byte, 32))
+		h.Write(buf)
+		mac := h.Sum(nil)
+		buf[0] = mac[0]
+	}
 }

--- a/openssl/openssl_evp.c
+++ b/openssl/openssl_evp.c
@@ -95,12 +95,12 @@ _goboringcrypto_EVP_PKEY_ref(GO_EVP_PKEY *pkey)
 
   switch (pkey->type) {
   case EVP_PKEY_EC:
-    if (_goboringcrypto_EVP_PKEY_set1_EC_KEY(result, _goboringcrypto_EVP_PKEY_get0_EC_KEY()) != 1)
+    if (_goboringcrypto_EVP_PKEY_assign_EC_KEY(result, _goboringcrypto_EVP_PKEY_get1_EC_KEY(pkey)) != 1)
       goto err;
     break;
 
   case EVP_PKEY_RSA:
-    if (_goboringcrypto_EVP_PKEY_set1_RSA_KEY(result, _goboringcrypto_EVP_PKEY_get0_RSA_KEY()) != 1)
+    if (_goboringcrypto_EVP_PKEY_assign_RSA(result, _goboringcrypto_EVP_PKEY_get1_RSA(pkey)) != 1)
       goto err;
 
     break;
@@ -114,5 +114,23 @@ _goboringcrypto_EVP_PKEY_ref(GO_EVP_PKEY *pkey)
 err:
   _goboringcrypto_EVP_PKEY_free(result);
   return NULL;
+}
+#endif
+
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+DEFINEFUNCINTERNAL(const GO_EC_KEY *, EVP_PKEY_get0_EC_KEY, (const GO_EVP_PKEY *pkey), (pkey));
+
+const GO_EC_KEY *
+_goboringcrypto_EVP_PKEY_get0_EC_KEY(const GO_EVP_PKEY *pkey)
+{
+  return _goboringcrypto_internal_EVP_PKEY_get0_EC_KEY(pkey);
+}
+#else
+DEFINEFUNCINTERNAL(void *, EVP_PKEY_get0, (EVP_PKEY *pkey), (pkey))
+
+const GO_EC_KEY *
+_goboringcrypto_EVP_PKEY_get0_EC_KEY(const GO_EVP_PKEY *pkey)
+{
+  return (const GO_EC_KEY *)_goboringcrypto_internal_EVP_PKEY_get0((EVP_PKEY *)pkey);
 }
 #endif

--- a/openssl/openssl_port_hmac.c
+++ b/openssl/openssl_port_hmac.c
@@ -7,10 +7,219 @@
 
 #include "goopenssl.h"
 
-// Not in OpenSSL 1.1.  However, HMAC_CTX_copy expects an initialized
-// target in OpenSSL 1.1.
-int _goboringcrypto_HMAC_CTX_copy_ex(GO_HMAC_CTX *dest,
-                                     const GO_HMAC_CTX *src) {
-  // HMAC_CTX_copy lacks the const qualifier for the second parameter.
-  return _goboringcrypto_HMAC_CTX_copy(dest, (GO_HMAC_CTX *)src);
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+
+DEFINEFUNCINTERNAL(EVP_PKEY *,
+		   EVP_PKEY_new_mac_key,
+		   (int type, ENGINE *e, const unsigned char *key, int keylen),
+		   (type, e, key, keylen))
+DEFINEFUNCINTERNAL(int, EVP_MD_CTX_reset, (EVP_MD_CTX *ctx), (ctx))
+DEFINEFUNCINTERNAL(const EVP_MD *, EVP_MD_CTX_get0_md, (const EVP_MD_CTX *ctx), (ctx))
+DEFINEFUNCINTERNAL(int, EVP_MD_CTX_copy_ex, (EVP_MD_CTX *out, const EVP_MD_CTX *in), (out, in))
+
+/* EVP_DigestSignUpdate is converted from a macro in 3.0 */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+DEFINEFUNCINTERNAL(int, EVP_DigestSignUpdate,
+		   (EVP_MD_CTX* ctx, const void *d, size_t cnt),
+		   (ctx, d, cnt))
+#endif
+
+struct go_hmac_ctx {
+  EVP_PKEY *pkey;
+  EVP_MD_CTX *mdctx;
+};
+
+GO_HMAC_CTX *
+_goboringcrypto_HMAC_CTX_new(const unsigned char *key, int keylen,
+			     const EVP_MD *md)
+{
+  EVP_PKEY *pkey = NULL;
+  EVP_MD_CTX *mdctx = NULL;
+  struct go_hmac_ctx *ctx;
+
+  pkey = _goboringcrypto_internal_EVP_PKEY_new_mac_key(EVP_PKEY_HMAC, NULL,
+						       key, keylen);
+  if (!pkey)
+    return NULL;
+
+  mdctx = _goboringcrypto_EVP_MD_CTX_create();
+  if (mdctx == NULL)
+    goto err;
+
+  if (_goboringcrypto_EVP_DigestSignInit(mdctx, NULL, md, NULL, pkey) != 1)
+    goto err;
+
+  ctx = malloc(sizeof(*ctx));
+  if (!ctx)
+    goto err;
+
+  ctx->pkey = pkey;
+  ctx->mdctx = mdctx;
+
+  return ctx;
+
+ err:
+  _goboringcrypto_EVP_PKEY_free(pkey);
+  _goboringcrypto_EVP_MD_CTX_free(mdctx);
+  return NULL;
 }
+
+int _goboringcrypto_HMAC_Update(GO_HMAC_CTX *ctx,
+				const unsigned char *data, size_t len)
+{
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  return _goboringcrypto_internal_EVP_DigestSignUpdate(ctx->mdctx, data, len);
+#else
+  return _goboringcrypto_EVP_DigestUpdate(ctx->mdctx, data, len);
+#endif
+}
+
+int _goboringcrypto_HMAC_CTX_reset(GO_HMAC_CTX *ctx)
+{
+  int ret;
+  const EVP_MD *md;
+
+  md = _goboringcrypto_internal_EVP_MD_CTX_get0_md(ctx->mdctx);
+  if (!md)
+    return -1;
+
+  ret = _goboringcrypto_internal_EVP_MD_CTX_reset(ctx->mdctx);
+  if (ret != 1)
+    return ret;
+
+  ret = _goboringcrypto_EVP_DigestSignInit(ctx->mdctx, NULL, md, NULL, ctx->pkey);
+  if (ret != 1)
+    return ret;
+
+  return 1;
+}
+
+void _goboringcrypto_HMAC_CTX_free(GO_HMAC_CTX *ctx)
+{
+  if (ctx) {
+    _goboringcrypto_EVP_PKEY_free(ctx->pkey);
+    _goboringcrypto_EVP_MD_CTX_free(ctx->mdctx);
+  }
+  free(ctx);
+}
+
+int _goboringcrypto_HMAC_Final(GO_HMAC_CTX *ctx,
+			       unsigned char *md, unsigned int *len)
+{
+  EVP_MD_CTX *mdctx = NULL;
+  size_t slen;
+  int ret = 0;
+
+  mdctx = _goboringcrypto_EVP_MD_CTX_create();
+  if (mdctx == NULL)
+    goto err;
+
+  if (_goboringcrypto_internal_EVP_MD_CTX_copy_ex(mdctx, ctx->mdctx) != 1)
+    goto err;
+
+  ret = _goboringcrypto_EVP_DigestSignFinal(mdctx, md, &slen);
+  if (ret == 1 && len)
+    *len = slen;
+
+ err:
+  _goboringcrypto_EVP_MD_CTX_free(mdctx);
+  return ret;
+}
+
+#else
+
+#include <openssl/hmac.h>
+
+DEFINEFUNCINTERNAL(int, HMAC_Init_ex,
+		   (HMAC_CTX *arg0, const void *arg1, int arg2, const EVP_MD *arg3, ENGINE *arg4),
+		   (arg0, arg1, arg2, arg3, arg4))
+DEFINEFUNCINTERNAL(int, HMAC_Update, (HMAC_CTX *arg0, const uint8_t *arg1, size_t arg2), (arg0, arg1, arg2))
+DEFINEFUNCINTERNAL(int, HMAC_Final, (HMAC_CTX *arg0, uint8_t *arg1, unsigned int *arg2), (arg0, arg1, arg2))
+DEFINEFUNCINTERNAL(size_t, HMAC_CTX_copy, (HMAC_CTX *dest, HMAC_CTX *src), (dest, src))
+DEFINEFUNCINTERNAL(void, HMAC_CTX_cleanup, (HMAC_CTX *arg0), (arg0))
+DEFINEFUNCINTERNAL(void, HMAC_CTX_init, (HMAC_CTX *arg0), (arg0))
+DEFINEFUNCINTERNAL(const EVP_MD *, HMAC_CTX_get_md, (const HMAC_CTX *ctx), (ctx))
+DEFINEFUNCINTERNAL(void, OPENSSL_cleanse, (void *ptr, size_t len), (ptr, len))
+
+struct go_hmac_ctx {
+  HMAC_CTX hctx;
+  unsigned char *key;
+  int keylen;
+};
+
+GO_HMAC_CTX *
+_goboringcrypto_HMAC_CTX_new(const unsigned char *key, int keylen,
+			     const EVP_MD *md)
+{
+  struct go_hmac_ctx *ctx;
+
+  ctx = malloc(sizeof(*ctx));
+  if (!ctx)
+    return NULL;
+
+  _goboringcrypto_internal_HMAC_CTX_init(&ctx->hctx);
+
+  if (_goboringcrypto_internal_HMAC_Init_ex(&ctx->hctx, key, keylen, md, NULL) != 1)
+    goto err;
+
+  ctx->key = malloc(keylen);
+  if (!ctx->key)
+    goto err;
+  memcpy(ctx->key, key, keylen);
+  ctx->keylen = keylen;
+
+  return ctx;
+
+ err:
+  _goboringcrypto_HMAC_CTX_free(ctx);
+  return NULL;
+}
+
+int _goboringcrypto_HMAC_Update(GO_HMAC_CTX *ctx,
+				const unsigned char *data, size_t len)
+{
+  return _goboringcrypto_internal_HMAC_Update(&ctx->hctx, data, len);
+}
+
+int _goboringcrypto_HMAC_CTX_reset(GO_HMAC_CTX *ctx)
+{
+  int ret;
+  const EVP_MD *md = ctx->hctx.md;
+
+  _goboringcrypto_internal_HMAC_CTX_init(&ctx->hctx);
+
+  ret = _goboringcrypto_internal_HMAC_Init_ex(&ctx->hctx, ctx->key, ctx->keylen, md, NULL);
+  if (ret != 1)
+    return ret;
+
+  return 1;
+}
+
+void _goboringcrypto_HMAC_CTX_free(GO_HMAC_CTX *ctx)
+{
+  _goboringcrypto_internal_HMAC_CTX_cleanup(&ctx->hctx);
+
+  if (ctx->key) {
+    _goboringcrypto_internal_OPENSSL_cleanse(ctx->key, ctx->keylen);
+    free(ctx->key);
+  }
+
+  free(ctx);
+}
+
+int _goboringcrypto_HMAC_Final(GO_HMAC_CTX *ctx,
+			       unsigned char *md, unsigned int *len)
+{
+  HMAC_CTX hctx;
+  int ret;
+
+  ret = _goboringcrypto_internal_HMAC_CTX_copy(&hctx, &ctx->hctx);
+  if (ret != 1)
+    return ret;
+
+  ret = _goboringcrypto_internal_HMAC_Final(&hctx, md, len);
+  _goboringcrypto_internal_HMAC_CTX_cleanup(&hctx);
+  return ret;
+}
+
+#endif

--- a/openssl/openssl_port_rsa.c
+++ b/openssl/openssl_port_rsa.c
@@ -35,6 +35,9 @@ GO_RSA *_goboringcrypto_RSA_generate_key_fips(int bits) {
   if (_goboringcrypto_EVP_PKEY_CTX_set_rsa_keygen_pubexp(ctx, e) <= 0)
     goto err;
 
+  /* EVP_PKEY_CTX_set_rsa_keygen_pubexp takes ownership of e */
+  e = NULL;
+
   if (_goboringcrypto_EVP_PKEY_keygen(ctx, &pkey) <= 0)
     goto err;
 


### PR DESCRIPTION
This makes the HMAC binding use the EVP_DigestSign interface instead of the deprecated HMAC_CTX functions, so that the implementation go through the FIPS provider when used with OpenSSL 3.