### PR TITLE
Wrap in/out length pointer APIs: avoid heap escape

### DIFF
--- a/ecdh.go
+++ b/ecdh.go
@@ -269,12 +269,12 @@ func ECDH(priv *PrivateKeyECDH, pub *PublicKeyECDH) ([]byte, error) {
 	if C.go_openssl_EVP_PKEY_derive_set_peer(ctx, pub._pkey) != 1 {
 		return nil, newOpenSSLError("EVP_PKEY_derive_set_peer")
 	}
-	var outLen C.size_t
-	if C.go_openssl_EVP_PKEY_derive(ctx, nil, &outLen) != 1 {
+	outLen := C.go_openssl_EVP_PKEY_derive_wrapper_get_len(ctx)
+	if outLen == 0 {
 		return nil, newOpenSSLError("EVP_PKEY_derive_init")
 	}
 	out := make([]byte, outLen)
-	if C.go_openssl_EVP_PKEY_derive(ctx, base(out), &outLen) != 1 {
+	if C.go_openssl_EVP_PKEY_derive_wrapper_with_len(ctx, base(out), outLen) != 1 {
 		return nil, newOpenSSLError("EVP_PKEY_derive_init")
 	}
 	return out, nil

--- a/ed25519.go
+++ b/ed25519.go
@@ -146,7 +146,7 @@ func NewPrivateKeyEd25519FromSeed(seed []byte) (*PrivateKeyEd25519, error) {
 
 func extractPKEYPubEd25519(pkey C.GO_EVP_PKEY_PTR, pub []byte) error {
 	pubSize := C.size_t(publicKeySizeEd25519)
-	if C.go_openssl_EVP_PKEY_get_raw_public_key(pkey, base(pub), &pubSize) != 1 {
+	if C.go_openssl_EVP_PKEY_get_raw_public_key_wrapper_with_len(pkey, base(pub), pubSize) != 1 {
 		return newOpenSSLError("EVP_PKEY_get_raw_public_key")
 	}
 	if pubSize != publicKeySizeEd25519 {
@@ -160,7 +160,7 @@ func extractPKEYPrivEd25519(pkey C.GO_EVP_PKEY_PTR, priv []byte) error {
 		return err
 	}
 	privSize := C.size_t(seedSizeEd25519)
-	if C.go_openssl_EVP_PKEY_get_raw_private_key(pkey, base(priv), &privSize) != 1 {
+	if C.go_openssl_EVP_PKEY_get_raw_private_key_wrapper_with_len(pkey, base(priv), privSize) != 1 {
 		return newOpenSSLError("EVP_PKEY_get_raw_private_key")
 	}
 	if privSize != seedSizeEd25519 {
@@ -191,7 +191,8 @@ func signEd25519(priv *PrivateKeyEd25519, sig, message []byte) error {
 		return newOpenSSLError("EVP_DigestSignInit")
 	}
 	siglen := C.size_t(signatureSizeEd25519)
-	if C.go_openssl_EVP_DigestSign(ctx, base(sig), &siglen, base(message), C.size_t(len(message))) != 1 {
+	siglen = C.go_openssl_EVP_DigestSign_wrapper_modify_len(ctx, base(sig), siglen, base(message), C.size_t(len(message)))
+	if siglen == 0 {
 		return newOpenSSLError("EVP_DigestSign")
 	}
 	if siglen != signatureSizeEd25519 {

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -90,7 +90,7 @@ func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
 		}
 	}
 	outLen := C.size_t(len(result))
-	if C.go_openssl_EVP_PKEY_derive(ctx, base(result), &outLen) != 1 {
+	if C.go_openssl_EVP_PKEY_derive_wrapper_with_len(ctx, base(result), outLen) != 1 {
 		return newOpenSSLError("EVP_PKEY_derive")
 	}
 	// The Go standard library expects TLS1PRF to return the requested number of bytes,


### PR DESCRIPTION
* Related: https://github.com/golang-fips/openssl/pull/129
* For: https://github.com/golang-fips/openssl/issues/128

Add wrappers that help avoid escape to the heap for this list:

https://github.com/golang-fips/openssl/blob/61234a910b77a1b4cabccee389684cbc372fd5ea/cgo_go122.go#L10-L17

There's only a benchmark for ECDH (EVP_PKEY_derive) but this PR shows the same results as https://github.com/golang-fips/openssl/pull/113:

```
goos: linux
goarch: amd64
pkg: github.com/golang-fips/openssl/v2
cpu: Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz
       │   old.txt   │           new.txt            │
       │   sec/op    │   sec/op     vs base         │
ECDH-8   104.1µ ± 3%   101.2µ ± 3%  ~ (p=0.065 n=8)

       │  old.txt   │              new.txt              │
       │    B/op    │    B/op     vs base               │
ECDH-8   40.00 ± 0%   32.00 ± 0%  -20.00% (p=0.000 n=8)

       │  old.txt   │              new.txt              │
       │ allocs/op  │ allocs/op   vs base               │
ECDH-8   2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=8)
```

---

The wrapper makes it so you can't distinguish a "valid" returned `0` vs. a `0` returned because there's an error, and I don't know for sure that won't cause problems in some use cases. (E.g. make an error show up in the wrong way.)

Returning a C struct with two values is what I have in mind make a more transparent wrapper that avoids losing this difference, but I figured I'd submit this PR first in case it's not worth the complexity. Please let me know if that seems better. (The benchmark result is the same when I tried this out for `EVP_PKEY_derive`.)