### PR TITLE
rsa: Allow omission of precomputed values in NewPrivateKeyRSA

### DIFF
--- a/rsa_test.go
+++ b/rsa_test.go
@@ -217,6 +217,8 @@ func newRSAKey(t *testing.T, size int) (*openssl.PrivateKeyRSA, *openssl.PublicK
 	if err != nil {
 		t.Fatalf("GenerateKeyRSA(%d): %v", size, err)
 	}
+	// Exercise omission of precomputed value
+	Dp = nil
 	priv, err := openssl.NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv)
 	if err != nil {
 		t.Fatalf("NewPrivateKeyRSA(%d): %v", size, err)


### PR DESCRIPTION
OpenSSL 3.0 and 3.1 required precomputed values for CRT (Dp, Dq, and Qinv), when the primes (P and Q) are included in the params array.

Since all of them can be derived from N, E, and D, this patch simply stops passing those values if any of them are missing.

See also: https://github.com/openssl/openssl/pull/22334