### PR TITLE
Add build tag excluding thread_setup.go during bootstrap

### DIFF
--- a/thread_setup.go
+++ b/thread_setup.go
@@ -1,3 +1,5 @@
+//go:build !cmd_go_bootstrap
+
 package openssl
 
 // Go wrappers for testing the thread setup code as _test.go files cannot import "C".


### PR DESCRIPTION
This file utilizes CGO which causes the bootstrap phase of the compiler build to fail.