### PR TITLE
Link against pthread

### DIFF
--- a/init_unix.go
+++ b/init_unix.go
@@ -2,7 +2,7 @@
 
 package openssl
 
-// #cgo LDFLAGS: -ldl
+// #cgo LDFLAGS: -ldl -pthread
 // #include <stdlib.h>
 // #include <dlfcn.h>
 import "C"


### PR DESCRIPTION
We depend on pthread but are not explicitly adding it to the cgo LDFLAGS.

It used to work well because most linkers add stub implementations for old pthread functions when pthread is not linked. Unfortunately, `pthread_setspecific` was (correctly) added in #122, and that function is not normally stubbed, producing a link error under some unusual Go build configurations (Go links to pthread by default when using cgo).

See for example https://dev.azure.com/dnceng-public/public/_build/results?buildId=610701&view=logs&j=83130289-bc24-5ceb-b14e-d37ab0e8c945&t=77a3104e-0b46-5a5f-bd95-f1acb3049de6&l=634.

This PR adds the missing `pthread` entry in the `#cgo LDFLAGS` directive.