### PR TITLE
Add OpenSSL test versions 3.3.0, 3.3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.20.x]
-        openssl-version: [1.0.2, 1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1]
+        openssl-version: [1.0.2, 1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1]
     runs-on: ubuntu-20.04
     steps:
     - name: Install build tools

--- a/scripts/openssl.sh
+++ b/scripts/openssl.sh
@@ -75,6 +75,22 @@ case "$version" in
         make="build_libs"
         install="install_fips"
         ;;
+    "3.3.0")
+        tag="openssl-3.3.0";
+        sha256="1a47bdc46fac256a0dc8efb696f7f76fa5f96049ba1b60fded5478bd3165c6d2"
+        fipsmodule_version=""
+        config="enable-fips"
+        make="build_libs"
+        install="install_fips"
+        ;;
+    "3.3.1")
+        tag="openssl-3.3.1";
+        sha256="133bf39b8d1635ac94a8483042cc448251b770a0d12c7af0c05ea895ddd98f1d"
+        fipsmodule_version=""
+        config="enable-fips"
+        make="build_libs"
+        install="install_fips"
+        ;;
     *)
         echo >&2 "error: unsupported OpenSSL version '$version'"
         exit 1 ;;


### PR DESCRIPTION
Increase coverage for 3.3.0, which a team in Microsoft is trying out, and 3.3.1 because it's the latest 3.3 version.