### PR TITLE
V1 fixes

### DIFF
--- a/openssl/notboring.go
+++ b/openssl/notboring.go
@@ -12,6 +12,7 @@ import (
 	"crypto/cipher"
 	"hash"
 	"io"
+	"math/big"
 )
 
 var enabled = false

--- a/openssl/openssl_port_hmac.c
+++ b/openssl/openssl_port_hmac.c
@@ -14,7 +14,12 @@ DEFINEFUNCINTERNAL(EVP_PKEY *,
 		   (int type, ENGINE *e, const unsigned char *key, int keylen),
 		   (type, e, key, keylen))
 DEFINEFUNCINTERNAL(int, EVP_MD_CTX_reset, (EVP_MD_CTX *ctx), (ctx))
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
 DEFINEFUNCINTERNAL(const EVP_MD *, EVP_MD_CTX_get0_md, (const EVP_MD_CTX *ctx), (ctx))
+#else
+DEFINEFUNCINTERNAL(const EVP_MD *, EVP_MD_CTX_md, (const EVP_MD_CTX *ctx), (ctx))
+#endif
 DEFINEFUNCINTERNAL(int, EVP_MD_CTX_copy_ex, (EVP_MD_CTX *out, const EVP_MD_CTX *in), (out, in))
 
 /* EVP_DigestSignUpdate is converted from a macro in 3.0 */
@@ -79,7 +84,13 @@ int _goboringcrypto_HMAC_CTX_reset(GO_HMAC_CTX *ctx)
   int ret;
   const EVP_MD *md;
 
+
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
   md = _goboringcrypto_internal_EVP_MD_CTX_get0_md(ctx->mdctx);
+#else
+  md = _goboringcrypto_internal_EVP_MD_CTX_md(ctx->mdctx);
+#endif
+
   if (!md)
     return -1;
 


### PR DESCRIPTION
* Add math/big import in notboring.go
* Use legacy EVP_MD_CTX_md in openssl 1.1