### PR TITLE
Add Azure Linux 3.0 coverage in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,4 +89,6 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Run Test
       run: go test -v ./...
-      continue-on-error: true # Go with FIPs / OpenSSL support on Azure Linux 3.0 is currently broken due to symcrypt change, so we ignore failures
+      # Go with FIPs / OpenSSL support on Azure Linux 3.0 is currently broken due to symcrypt change, so we ignore failures.
+      # See https://github.com/golang-fips/openssl/issues/158.
+      continue-on-error: true 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,7 +86,7 @@ jobs:
     container: mcr.microsoft.com/oss/go/microsoft/golang:1.23-azurelinux3.0
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Run Test
       run: go test -v ./...
-      continue-on-error: true # Azure Linux is currently not supported, so we ignore failures
+      continue-on-error: true # Go with FIPs / OpenSSL support on Azure Linux 3.0 is currently broken due to symcrypt change, so we ignore failures

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,3 +81,12 @@ jobs:
       run: go test -gcflags=all=-d=checkptr -count 10 -v ./...
       env:
         GO_OPENSSL_VERSION_OVERRIDE: ${{ matrix.openssl-version }}
+  azurelinux:
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/oss/go/microsoft/golang:1.23-azurelinux3.0
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Run Test
+      run: go test -v ./...
+      continue-on-error: true # Azure Linux is currently not supported, so we ignore failures


### PR DESCRIPTION
This PR adds a GitHub Actions job that runs on Azure Linux 3.

Azure Linux 3.0 uses the [SymCrypt-OpenSSL](https://github.com/microsoft/SymCrypt-OpenSSL) provider, which has some limitations in terms of supported algorithms. Given that Azure Linux is a first class target for us (the Microsoft maintainers of this module), it would be helpful to run the CI test suit on that distro.