### PR TITLE
Avoid SymCrypt provider logs in TestECDSASignAndVerify

### DIFF
--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -70,10 +70,10 @@ func testECDSASignAndVerify(t *testing.T, c elliptic.Curve) {
 	if !openssl.VerifyECDSA(pub, hashed[:], signed) {
 		t.Errorf("Verify failed")
 	}
-	// Alter the last byte of the signature to make it invalid
-	// without corrupting the DER encoding, which would cause
-	// some OpenSSL providers, such as SymCrypt-OpenSSL, to write
-	// a noisy warning to stderr.
+	// Alter the signature to intentionally make it invalid. Change the last
+	// byte (rather than the first) to avoid corrupting the DER encoding, which
+	// would cause some OpenSSL providers, such as SymCrypt-OpenSSL, to write a
+	// noisy warning to stderr.
 	signed[len(signed)-1] ^= 0xff
 	if openssl.VerifyECDSA(pub, hashed[:], signed) {
 		t.Errorf("Verify succeeded despite intentionally invalid hash!")

--- a/ecdsa_test.go
+++ b/ecdsa_test.go
@@ -70,7 +70,11 @@ func testECDSASignAndVerify(t *testing.T, c elliptic.Curve) {
 	if !openssl.VerifyECDSA(pub, hashed[:], signed) {
 		t.Errorf("Verify failed")
 	}
-	signed[0] ^= 0xff
+	// Alter the last byte of the signature to make it invalid
+	// without corrupting the DER encoding, which would cause
+	// some OpenSSL providers, such as SymCrypt-OpenSSL, to write
+	// a noisy warning to stderr.
+	signed[len(signed)-1] ^= 0xff
 	if openssl.VerifyECDSA(pub, hashed[:], signed) {
 		t.Errorf("Verify succeeded despite intentionally invalid hash!")
 	}
@@ -81,7 +85,7 @@ func testECDSASignAndVerify(t *testing.T, c elliptic.Curve) {
 	if !openssl.HashVerifyECDSA(pub, crypto.SHA256, msg, signed) {
 		t.Errorf("Verify failed")
 	}
-	signed[0] ^= 0xff
+	signed[len(signed)-1] ^= 0xff
 	if openssl.HashVerifyECDSA(pub, crypto.SHA256, msg, signed) {
 		t.Errorf("Verify failed")
 	}


### PR DESCRIPTION
When using the [SymCrypt-OpenSSL](https://github.com/microsoft/SymCrypt-OpenSSL) provider, `openssl.VerifyECDSA` writes to stderr a log message if the ECDSA signature is not correctly DER encoded. That write is not in our code, but in `SymCrypt-OpenSSL`, so we can't make it disappear.

`TestECDSASignAndVerify` currently modifies the first byte of a valid ECDSA signature to test that `openssl.VerifyECDSA` correctly detect invalid signatures. The first byte is part of the DER encoding, so running that test using `SymCrypt-OpenSSL` is very verbose: 

```cmd
go test -v -run TestECDSASignAndVerify/P256
Using libcrypto.so.3
OpenSSL version: OpenSSL 3.3.0 9 Apr 2024
FIPS enabled: false
=== RUN   TestECDSASignAndVerify
=== RUN   TestECDSASignAndVerify/P256
=== PAUSE TestECDSASignAndVerify/P256
=== CONT  TestECDSASignAndVerify/P256
[ERROR] error:41080106:SCOSSL::passed invalid argument:pbDerField[0] != 0x30 at /usr/src/azl/BUILD/SymCrypt-OpenSSL-1.5.1/ScosslCommon/src/scossl_ecc.c, line 250
[ERROR] error:410C0107:SCOSSL::operation fail:scossl_ecdsa_remove_der failed at /usr/src/azl/BUILD/SymCrypt-OpenSSL-1.5.1/ScosslCommon/src/scossl_ecc.c, line 586
[ERROR] error:41080106:SCOSSL::passed invalid argument:pbDerField[0] != 0x30 at /usr/src/azl/BUILD/SymCrypt-OpenSSL-1.5.1/ScosslCommon/src/scossl_ecc.c, line 250
[ERROR] error:410C0107:SCOSSL::operation fail:scossl_ecdsa_remove_der failed at /usr/src/azl/BUILD/SymCrypt-OpenSSL-1.5.1/ScosslCommon/src/scossl_ecc.c, line 586
--- PASS: TestECDSASignAndVerify (0.00s)
    --- PASS: TestECDSASignAndVerify/P256 (0.02s)
```

This PR makes `TestECDSASignAndVerify` less verbose by altering the last byte of the signature instead of the first one, which is not part of the DER encoding.