### PR TITLE
Bump minimum Go version to 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.22.x]
         openssl-version: [1.0.2, 1.1.0, 1.1.1, 3.0.1, 3.0.13, 3.1.5, 3.2.1, 3.3.0, 3.3.1]
     runs-on: ubuntu-20.04
     steps:
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.22.x]
         openssl-version: [libcrypto-1_1-x64.dll, libcrypto-3-x64.dll]
     steps:
     - name: Install Go
@@ -67,7 +67,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.20.x]
+        go-version: [1.22.x]
         openssl-version: [libcrypto.3.dylib]
     runs-on: macos-12
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/golang-fips/openssl/v2
 
-go 1.20
+go 1.22


### PR DESCRIPTION
Require at least Go 1.22 to build this module. None of the maintainers is using it in a toolchain older than Go 1.22, and there are some new convenient functions that can simplify the code (e.g. [sync.OnceValue](https://pkg.go.dev/sync#OnceValue)).