### PR TITLE
Only implement encoding.BinaryMarshaler for hashers provided by built-in providers

### DIFF
--- a/evp.go
+++ b/evp.go
@@ -20,15 +20,15 @@ var cacheMD sync.Map
 func hashToMD(h hash.Hash) C.GO_EVP_MD_PTR {
 	var ch crypto.Hash
 	switch h.(type) {
-	case *sha1Hash:
+	case *sha1Hash, *sha1Marshal:
 		ch = crypto.SHA1
-	case *sha224Hash:
+	case *sha224Hash, *sha224Marshal:
 		ch = crypto.SHA224
-	case *sha256Hash:
+	case *sha256Hash, *sha256Marshal:
 		ch = crypto.SHA256
-	case *sha384Hash:
+	case *sha384Hash, *sha384Marshal:
 		ch = crypto.SHA384
-	case *sha512Hash:
+	case *sha512Hash, *sha512Marshal:
 		ch = crypto.SHA512
 	case *sha3_224Hash:
 		ch = crypto.SHA3_224

--- a/hash.go
+++ b/hash.go
@@ -115,14 +115,14 @@ var isMarshallableMap sync.Map
 
 // isHashMarshallable returns true if the memory layout of cb
 // is known by this library and can therefore be marshalled.
-func isHashMarshallable(cb crypto.Hash) bool {
+func isHashMarshallable(ch crypto.Hash) bool {
 	if vMajor == 1 {
 		return true
 	}
-	if v, ok := isMarshallableMap.Load(cb); ok {
+	if v, ok := isMarshallableMap.Load(ch); ok {
 		return v.(bool)
 	}
-	md := cryptoHashToMD(cb)
+	md := cryptoHashToMD(ch)
 	if md == nil {
 		return false
 	}
@@ -138,7 +138,7 @@ func isHashMarshallable(cb crypto.Hash) bool {
 	// We only know the memory layout of the built-in providers.
 	// See evpHash.hashState for more details.
 	marshallable := name == "default" || name == "fips"
-	isMarshallableMap.Store(cb, marshallable)
+	isMarshallableMap.Store(ch, marshallable)
 	return marshallable
 }
 
@@ -276,11 +276,11 @@ func (h *md4Hash) Sum(in []byte) []byte {
 
 // NewMD5 returns a new MD5 hash.
 func NewMD5() hash.Hash {
-	h := newEvpHash(crypto.MD5, 16, 64)
+	h := md5Hash{evpHash: newEvpHash(crypto.MD5, 16, 64)}
 	if isHashMarshallable(crypto.MD5) {
-		return &md5Marshal{md5Hash{evpHash: h}}
+		return &md5Marshal{h}
 	}
-	return &md5Hash{evpHash: h}
+	return &h
 }
 
 // md5State layout is taken from
@@ -354,11 +354,11 @@ func (h *md5Marshal) UnmarshalBinary(b []byte) error {
 
 // NewSHA1 returns a new SHA1 hash.
 func NewSHA1() hash.Hash {
-	h := newEvpHash(crypto.SHA1, 20, 64)
+	h := sha1Hash{evpHash: newEvpHash(crypto.SHA1, 20, 64)}
 	if isHashMarshallable(crypto.SHA1) {
-		return &sha1Marshal{sha1Hash{evpHash: h}}
+		return &sha1Marshal{h}
 	}
-	return &sha1Hash{evpHash: h}
+	return &h
 }
 
 type sha1Hash struct {
@@ -434,11 +434,11 @@ func (h *sha1Marshal) UnmarshalBinary(b []byte) error {
 
 // NewSHA224 returns a new SHA224 hash.
 func NewSHA224() hash.Hash {
-	h := newEvpHash(crypto.SHA224, 224/8, 64)
+	h := sha224Hash{evpHash: newEvpHash(crypto.SHA224, 224/8, 64)}
 	if isHashMarshallable(crypto.SHA224) {
-		return &sha224Marshal{sha224Hash{evpHash: h}}
+		return &sha224Marshal{h}
 	}
-	return &sha224Hash{evpHash: h}
+	return &h
 }
 
 type sha224Hash struct {
@@ -453,11 +453,11 @@ func (h *sha224Hash) Sum(in []byte) []byte {
 
 // NewSHA256 returns a new SHA256 hash.
 func NewSHA256() hash.Hash {
-	h := newEvpHash(crypto.SHA256, 256/8, 64)
+	h := sha256Hash{evpHash: newEvpHash(crypto.SHA256, 256/8, 64)}
 	if isHashMarshallable(crypto.SHA256) {
-		return &sha256Marshal{sha256Hash{evpHash: h}}
+		return &sha256Marshal{h}
 	}
-	return &sha256Hash{evpHash: h}
+	return &h
 }
 
 type sha256Hash struct {
@@ -593,11 +593,11 @@ func (h *sha256Marshal) UnmarshalBinary(b []byte) error {
 
 // NewSHA384 returns a new SHA384 hash.
 func NewSHA384() hash.Hash {
-	h := newEvpHash(crypto.SHA384, 384/8, 128)
+	h := sha384Hash{evpHash: newEvpHash(crypto.SHA384, 384/8, 128)}
 	if isHashMarshallable(crypto.SHA384) {
-		return &sha384Marshal{sha384Hash{evpHash: h}}
+		return &sha384Marshal{h}
 	}
-	return &sha384Hash{evpHash: h}
+	return &h
 }
 
 type sha384Hash struct {
@@ -612,11 +612,11 @@ func (h *sha384Hash) Sum(in []byte) []byte {
 
 // NewSHA512 returns a new SHA512 hash.
 func NewSHA512() hash.Hash {
-	h := newEvpHash(crypto.SHA512, 512/8, 128)
+	h := sha512Hash{evpHash: newEvpHash(crypto.SHA512, 512/8, 128)}
 	if isHashMarshallable(crypto.SHA512) {
-		return &sha512Marshal{sha512Hash{evpHash: h}}
+		return &sha512Marshal{h}
 	}
-	return &sha512Hash{evpHash: h}
+	return &h
 }
 
 type sha512Hash struct {

--- a/hash.go
+++ b/hash.go
@@ -113,8 +113,8 @@ func SHA3_512(p []byte) (sum [64]byte) {
 
 var isMarshallableMap sync.Map
 
-// isHashMarshallable returns true if its memory layout
-// is known by this library, therefore it can be marshalled.
+// isHashMarshallable returns true if the memory layout of cb
+// is known by this library and can therefore be marshalled.
 func isHashMarshallable(cb crypto.Hash) bool {
 	if vMajor == 1 {
 		return true
@@ -135,7 +135,7 @@ func isHashMarshallable(cb crypto.Hash) bool {
 		return false
 	}
 	name := C.GoString(cname)
-	// We only known the memory layout of the built-in providers.
+	// We only know the memory layout of the built-in providers.
 	// See evpHash.hashState for more details.
 	marshallable := name == "default" || name == "fips"
 	isMarshallableMap.Store(cb, marshallable)

--- a/hash_test.go
+++ b/hash_test.go
@@ -54,14 +54,14 @@ func TestHash(t *testing.T) {
 		crypto.SHA3_384,
 		crypto.SHA3_512,
 	}
-	for _, cb := range tests {
-		cb := cb
-		t.Run(cb.String(), func(t *testing.T) {
+	for _, ch := range tests {
+		ch := ch
+		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
-			if !openssl.SupportsHash(cb) {
+			if !openssl.SupportsHash(ch) {
 				t.Skip("skipping: not supported")
 			}
-			h := cryptoToHash(cb)()
+			h := cryptoToHash(ch)()
 			initSum := h.Sum(nil)
 			n, err := h.Write(msg)
 			if err != nil {
@@ -82,7 +82,7 @@ func TestHash(t *testing.T) {
 				if err != nil {
 					t.Errorf("could not marshal: %v", err)
 				}
-				h2 := cryptoToHash(cb)()
+				h2 := cryptoToHash(ch)()
 				if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
 					t.Errorf("could not unmarshal: %v", err)
 				}

--- a/hash_test.go
+++ b/hash_test.go
@@ -41,30 +41,27 @@ func cryptoToHash(h crypto.Hash) func() hash.Hash {
 
 func TestHash(t *testing.T) {
 	msg := []byte("testing")
-	var tests = []struct {
-		h            crypto.Hash
-		hasMarshaler bool
-	}{
-		{crypto.MD4, false},
-		{crypto.MD5, true},
-		{crypto.SHA1, true},
-		{crypto.SHA224, true},
-		{crypto.SHA256, true},
-		{crypto.SHA384, true},
-		{crypto.SHA512, true},
-		{crypto.SHA3_224, false},
-		{crypto.SHA3_256, false},
-		{crypto.SHA3_384, false},
-		{crypto.SHA3_512, false},
+	var tests = []crypto.Hash{
+		crypto.MD4,
+		crypto.MD5,
+		crypto.SHA1,
+		crypto.SHA224,
+		crypto.SHA256,
+		crypto.SHA384,
+		crypto.SHA512,
+		crypto.SHA3_224,
+		crypto.SHA3_256,
+		crypto.SHA3_384,
+		crypto.SHA3_512,
 	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.h.String(), func(t *testing.T) {
+	for _, cb := range tests {
+		cb := cb
+		t.Run(cb.String(), func(t *testing.T) {
 			t.Parallel()
-			if !openssl.SupportsHash(tt.h) {
+			if !openssl.SupportsHash(cb) {
 				t.Skip("skipping: not supported")
 			}
-			h := cryptoToHash(tt.h)()
+			h := cryptoToHash(cb)()
 			initSum := h.Sum(nil)
 			n, err := h.Write(msg)
 			if err != nil {
@@ -80,12 +77,12 @@ func TestHash(t *testing.T) {
 			if bytes.Equal(sum, initSum) {
 				t.Error("Write didn't change internal hash state")
 			}
-			if tt.hasMarshaler {
+			if _, ok := h.(encoding.BinaryMarshaler); ok {
 				state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
 				if err != nil {
 					t.Errorf("could not marshal: %v", err)
 				}
-				h2 := cryptoToHash(tt.h)()
+				h2 := cryptoToHash(cb)()
 				if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
 					t.Errorf("could not unmarshal: %v", err)
 				}

--- a/shims.h
+++ b/shims.h
@@ -190,9 +190,11 @@ DEFINEFUNC_3_0(int, EVP_default_properties_is_fips_enabled, (GO_OSSL_LIB_CTX_PTR
 DEFINEFUNC_3_0(int, EVP_default_properties_enable_fips, (GO_OSSL_LIB_CTX_PTR libctx, int enable), (libctx, enable)) \
 DEFINEFUNC_3_0(int, OSSL_PROVIDER_available, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
 DEFINEFUNC_3_0(GO_OSSL_PROVIDER_PTR, OSSL_PROVIDER_load, (GO_OSSL_LIB_CTX_PTR libctx, const char *name), (libctx, name)) \
+DEFINEFUNC_3_0(const char *, OSSL_PROVIDER_get0_name, (const GO_OSSL_PROVIDER_PTR prov), (prov)) \
 DEFINEFUNC_3_0(GO_EVP_MD_PTR, EVP_MD_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
 DEFINEFUNC_3_0(void, EVP_MD_free, (GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC_3_0(const char *, EVP_MD_get0_name, (const GO_EVP_MD_PTR md), (md)) \
+DEFINEFUNC_3_0(const GO_OSSL_PROVIDER_PTR, EVP_MD_get0_provider, (const GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC(int, RAND_bytes, (unsigned char *arg0, int arg1), (arg0, arg1)) \
 DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (void), ()) \
 DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \

--- a/shims.h
+++ b/shims.h
@@ -195,7 +195,7 @@ DEFINEFUNC_3_0(GO_EVP_MD_PTR, EVP_MD_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char
 DEFINEFUNC_3_0(void, EVP_MD_free, (GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC_3_0(const char *, EVP_MD_get0_name, (const GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC_3_0(const GO_OSSL_PROVIDER_PTR, EVP_MD_get0_provider, (const GO_EVP_MD_PTR md), (md)) \
-DEFINEFUNC(int, EVP_MD_get_block_size, (const GO_EVP_MD_PTR md), (md)) \
+DEFINEFUNC_RENAMED_3_0(int, EVP_MD_get_block_size, EVP_MD_block_size, (const GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC(int, RAND_bytes, (unsigned char *arg0, int arg1), (arg0, arg1)) \
 DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (void), ()) \
 DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \

--- a/shims.h
+++ b/shims.h
@@ -195,6 +195,7 @@ DEFINEFUNC_3_0(GO_EVP_MD_PTR, EVP_MD_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char
 DEFINEFUNC_3_0(void, EVP_MD_free, (GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC_3_0(const char *, EVP_MD_get0_name, (const GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC_3_0(const GO_OSSL_PROVIDER_PTR, EVP_MD_get0_provider, (const GO_EVP_MD_PTR md), (md)) \
+DEFINEFUNC(int, EVP_MD_get_block_size, (const GO_EVP_MD_PTR md), (md)) \
 DEFINEFUNC(int, RAND_bytes, (unsigned char *arg0, int arg1), (arg0, arg1)) \
 DEFINEFUNC_RENAMED_1_1(GO_EVP_MD_CTX_PTR, EVP_MD_CTX_new, EVP_MD_CTX_create, (void), ()) \
 DEFINEFUNC_RENAMED_1_1(void, EVP_MD_CTX_free, EVP_MD_CTX_destroy, (GO_EVP_MD_CTX_PTR ctx), (ctx)) \


### PR DESCRIPTION
We can only marshal/unmarshal the internal state of hashers provided by built-in providers, which are the only ones from which we know the memory layout.

This PR does some struct embedding tricks so the hashers returned by`NewMD5`, `NewSHA1`, `NewSHA224`, `NewSHA256`, `NewSHA384`, and `NewSHA512`, only implement the `encoding.BinaryMarshaler` and `encoding.BinaryUnmarshaler` interface if the hashers are provided by the fips or the default provider.

Fixes #156.