### PR TITLE
Only omit RSA primes if precomputed values are missing in OpenSSL 3.0 and 3.1

### DIFF
--- a/rsa.go
+++ b/rsa.go
@@ -396,14 +396,15 @@ func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (C.GO_EVP_PKEY_
 	}
 	comps = append(comps, required[:]...)
 
-	// OpenSSL 3.0 and 3.1 required all the precomputed values if
-	// P and Q are present. See:
-	// https://github.com/openssl/openssl/pull/22334
-	if vMinor >= 2 || (p != nil && q != nil && dp != nil && dq != nil && qinv != nil) {
-		if p != nil && q != nil {
+	if p != nil && q != nil {
+		allPrecomputedExists := dp != nil && dq != nil && qinv != nil
+		// OpenSSL 3.0 and 3.1 required all the precomputed values if
+		// P and Q are present. If they are not, we need to omit also P and Q.
+		// See https://github.com/openssl/openssl/pull/22334
+		if vMinor >= 2 || allPrecomputedExists {
 			comps = append(comps, bigIntParam{OSSL_PKEY_PARAM_RSA_FACTOR1, p}, bigIntParam{OSSL_PKEY_PARAM_RSA_FACTOR2, q})
 		}
-		if dp != nil && dq != nil && qinv != nil {
+		if allPrecomputedExists {
 			comps = append(comps,
 				bigIntParam{OSSL_PKEY_PARAM_RSA_EXPONENT1, dp},
 				bigIntParam{OSSL_PKEY_PARAM_RSA_EXPONENT2, dq},

--- a/rsa.go
+++ b/rsa.go
@@ -399,7 +399,7 @@ func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (C.GO_EVP_PKEY_
 	// OpenSSL 3.0 and 3.1 required all the precomputed values if
 	// P and Q are present. See:
 	// https://github.com/openssl/openssl/pull/22334
-	if p != nil && q != nil && dp != nil && dq != nil && qinv != nil {
+	if vMinor >= 2 || (p != nil && q != nil && dp != nil && dq != nil && qinv != nil) {
 		precomputed := [...]bigIntParam{
 			{OSSL_PKEY_PARAM_RSA_FACTOR1, p}, {OSSL_PKEY_PARAM_RSA_FACTOR2, q},
 			{OSSL_PKEY_PARAM_RSA_EXPONENT1, dp}, {OSSL_PKEY_PARAM_RSA_EXPONENT2, dq}, {OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qinv},

--- a/rsa.go
+++ b/rsa.go
@@ -398,9 +398,12 @@ func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (C.GO_EVP_PKEY_
 
 	if p != nil && q != nil {
 		allPrecomputedExists := dp != nil && dq != nil && qinv != nil
-		// OpenSSL 3.0 and 3.1 required all the precomputed values if
-		// P and Q are present. If they are not, we need to omit also P and Q.
-		// See https://github.com/openssl/openssl/pull/22334
+		// The precomputed values should only be passed if P and Q are present
+		// and every precomputed value is present. (If any precomputed value is
+		// missing, don't pass any of them.)
+		//
+		// In OpenSSL 3.0 and 3.1, we must also omit P and Q if any precomputed
+		// value is missing. See https://github.com/openssl/openssl/pull/22334
 		if vMinor >= 2 || allPrecomputedExists {
 			comps = append(comps, bigIntParam{OSSL_PKEY_PARAM_RSA_FACTOR1, p}, bigIntParam{OSSL_PKEY_PARAM_RSA_FACTOR2, q})
 		}

--- a/rsa.go
+++ b/rsa.go
@@ -400,11 +400,16 @@ func newRSAKey3(isPriv bool, n, e, d, p, q, dp, dq, qinv BigInt) (C.GO_EVP_PKEY_
 	// P and Q are present. See:
 	// https://github.com/openssl/openssl/pull/22334
 	if vMinor >= 2 || (p != nil && q != nil && dp != nil && dq != nil && qinv != nil) {
-		precomputed := [...]bigIntParam{
-			{OSSL_PKEY_PARAM_RSA_FACTOR1, p}, {OSSL_PKEY_PARAM_RSA_FACTOR2, q},
-			{OSSL_PKEY_PARAM_RSA_EXPONENT1, dp}, {OSSL_PKEY_PARAM_RSA_EXPONENT2, dq}, {OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qinv},
+		if p != nil && q != nil {
+			comps = append(comps, bigIntParam{OSSL_PKEY_PARAM_RSA_FACTOR1, p}, bigIntParam{OSSL_PKEY_PARAM_RSA_FACTOR2, q})
 		}
-		comps = append(comps, precomputed[:]...)
+		if dp != nil && dq != nil && qinv != nil {
+			comps = append(comps,
+				bigIntParam{OSSL_PKEY_PARAM_RSA_EXPONENT1, dp},
+				bigIntParam{OSSL_PKEY_PARAM_RSA_EXPONENT2, dq},
+				bigIntParam{OSSL_PKEY_PARAM_RSA_COEFFICIENT1, qinv},
+			)
+		}
 	}
 
 	for _, comp := range comps {

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -17,7 +17,69 @@ func TestRSAKeyGeneration(t *testing.T) {
 		size := size
 		t.Run(strconv.Itoa(size), func(t *testing.T) {
 			t.Parallel()
+			_, _, _, _, _, _, _, _, err := openssl.GenerateKeyRSA(size)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func testRSAEncryptDecryptPKCS1(t *testing.T, priv *openssl.PrivateKeyRSA, pub *openssl.PublicKeyRSA) {
+	msg := []byte("hi!")
+	enc, err := openssl.EncryptRSAPKCS1(pub, msg)
+	if err != nil {
+		t.Fatalf("EncryptPKCS1v15: %v", err)
+	}
+	dec, err := openssl.DecryptRSAPKCS1(priv, enc)
+	if err != nil {
+		t.Fatalf("DecryptPKCS1v15: %v", err)
+	}
+	if !bytes.Equal(dec, msg) {
+		t.Fatalf("got:%x want:%x", dec, msg)
+	}
+}
+
+func TestRSAEncryptDecryptPKCS1(t *testing.T) {
+	for _, size := range []int{2048, 3072} {
+		size := size
+		t.Run(strconv.Itoa(size), func(t *testing.T) {
+			t.Parallel()
 			priv, pub := newRSAKey(t, size)
+			testRSAEncryptDecryptPKCS1(t, priv, pub)
+		})
+	}
+}
+
+func TestRSAEncryptDecryptPKCS1_MissingPrecomputedValues(t *testing.T) {
+	N, E, D, P, Q, Dp, Dq, Qinv, err := openssl.GenerateKeyRSA(2048)
+	if err != nil {
+		t.Fatalf("GenerateKeyRSA: %v", err)
+	}
+	tt := []struct {
+		name    string
+		wantErr bool
+		fn      func() (*openssl.PrivateKeyRSA, *openssl.PublicKeyRSA)
+	}{
+		{"noDp", false, func() (*openssl.PrivateKeyRSA, *openssl.PublicKeyRSA) {
+			return newRSAKeyFromParams(t, N, E, D, P, Q, nil, Dq, Qinv)
+		}},
+		{"noDq", false, func() (*openssl.PrivateKeyRSA, *openssl.PublicKeyRSA) {
+			return newRSAKeyFromParams(t, N, E, D, P, Q, Dp, nil, Qinv)
+		}},
+		{"noQinv", false, func() (*openssl.PrivateKeyRSA, *openssl.PublicKeyRSA) {
+			return newRSAKeyFromParams(t, N, E, D, P, Q, Dp, Dq, nil)
+		}},
+		{"none", false, func() (*openssl.PrivateKeyRSA, *openssl.PublicKeyRSA) {
+			return newRSAKeyFromParams(t, N, E, D, P, Q, nil, nil, nil)
+		}},
+	}
+	for _, tt := range tt {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			priv, pub := tt.fn()
+			testRSAEncryptDecryptPKCS1(t, priv, pub)
 			msg := []byte("hi!")
 			enc, err := openssl.EncryptRSAPKCS1(pub, msg)
 			if err != nil {
@@ -34,7 +96,7 @@ func TestRSAKeyGeneration(t *testing.T) {
 	}
 }
 
-func TestEncryptDecryptOAEP(t *testing.T) {
+func TestRSAEncryptDecryptOAEP(t *testing.T) {
 	sha256 := openssl.NewSHA256()
 	msg := []byte("hi!")
 	label := []byte("ho!")
@@ -57,7 +119,7 @@ func TestEncryptDecryptOAEP(t *testing.T) {
 	}
 }
 
-func TestEncryptDecryptOAEP_EmptyLabel(t *testing.T) {
+func TestRSAEncryptDecryptOAEP_EmptyLabel(t *testing.T) {
 	sha256 := openssl.NewSHA256()
 	msg := []byte("hi!")
 	label := []byte("")
@@ -80,7 +142,7 @@ func TestEncryptDecryptOAEP_EmptyLabel(t *testing.T) {
 	}
 }
 
-func TestEncryptDecryptOAEP_WithMGF1Hash(t *testing.T) {
+func TestRSAEncryptDecryptOAEP_WithMGF1Hash(t *testing.T) {
 	if openssl.SymCryptProviderAvailable() {
 		t.Skip("SymCrypt provider does not support MGF1 hash")
 	}
@@ -107,7 +169,7 @@ func TestEncryptDecryptOAEP_WithMGF1Hash(t *testing.T) {
 	}
 }
 
-func TestEncryptDecryptOAEP_WrongLabel(t *testing.T) {
+func TestRSAEncryptDecryptOAEP_WrongLabel(t *testing.T) {
 	sha256 := openssl.NewSHA256()
 	msg := []byte("hi!")
 	priv, pub := newRSAKey(t, 2048)
@@ -124,7 +186,7 @@ func TestEncryptDecryptOAEP_WrongLabel(t *testing.T) {
 	}
 }
 
-func TestSignVerifyPKCS1v15(t *testing.T) {
+func TestRSASignVerifyPKCS1v15(t *testing.T) {
 	sha256 := openssl.NewSHA256()
 	priv, pub := newRSAKey(t, 2048)
 	msg := []byte("hi!")
@@ -151,7 +213,7 @@ func TestSignVerifyPKCS1v15(t *testing.T) {
 	}
 }
 
-func TestSignVerifyPKCS1v15_Unhashed(t *testing.T) {
+func TestRSASignVerifyPKCS1v15_Unhashed(t *testing.T) {
 	if openssl.SymCryptProviderAvailable() {
 		t.Skip("SymCrypt provider does not support unhashed PKCS1v15")
 	}
@@ -168,7 +230,7 @@ func TestSignVerifyPKCS1v15_Unhashed(t *testing.T) {
 	}
 }
 
-func TestSignVerifyPKCS1v15_Invalid(t *testing.T) {
+func TestRSASignVerifyPKCS1v15_Invalid(t *testing.T) {
 	sha256 := openssl.NewSHA256()
 	msg := []byte("hi!")
 	priv, pub := newRSAKey(t, 2048)
@@ -184,7 +246,7 @@ func TestSignVerifyPKCS1v15_Invalid(t *testing.T) {
 	}
 }
 
-func TestSignVerifyRSAPSS(t *testing.T) {
+func TestRSASignVerifyRSAPSS(t *testing.T) {
 	// Test cases taken from
 	// https://github.com/golang/go/blob/54182ff54a687272dd7632c3a963e036ce03cb7c/src/crypto/rsa/pss_test.go#L200.
 	const keyBits = 2048
@@ -225,15 +287,18 @@ func newRSAKey(t *testing.T, size int) (*openssl.PrivateKeyRSA, *openssl.PublicK
 	if err != nil {
 		t.Fatalf("GenerateKeyRSA(%d): %v", size, err)
 	}
-	// Exercise omission of precomputed value
-	Dp = nil
+	return newRSAKeyFromParams(t, N, E, D, P, Q, Dp, Dq, Qinv)
+}
+
+func newRSAKeyFromParams(t *testing.T, N, E, D, P, Q, Dp, Dq, Qinv openssl.BigInt) (*openssl.PrivateKeyRSA, *openssl.PublicKeyRSA) {
+	t.Helper()
 	priv, err := openssl.NewPrivateKeyRSA(N, E, D, P, Q, Dp, Dq, Qinv)
 	if err != nil {
-		t.Fatalf("NewPrivateKeyRSA(%d): %v", size, err)
+		t.Fatalf("NewPrivateKeyRSA: %v", err)
 	}
 	pub, err := openssl.NewPublicKeyRSA(N, E)
 	if err != nil {
-		t.Fatalf("NewPublicKeyRSA(%d): %v", size, err)
+		t.Fatalf("NewPublicKeyRSA: %v", err)
 	}
 	return priv, pub
 }


### PR DESCRIPTION
Since OpenSSL 3.2, RSA primes can coexist with empty precomputed values, see https://github.com/openssl/openssl/pull/22334.
Some providers, such as SymCrypt, compute the RSA private key using the prime numbers `P` and `Q` instead of loading it from the private exponent `D`. So they always need `P` and `Q`, even if the precomputed values are omitted. This means that these providers are not fully compatible with OpenSSL 3.0 and 3.1, but they do work with OpenSSL 3.2 and higher.

This PR relaxes the restriction added in #136 to only take effect with OpenSSL 3.0 and 3.1.