### PR TITLE
Skip tests not supported by SymCrypt

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -5,5 +5,8 @@ import "sync"
 var ErrOpen = errOpen
 
 var SymCryptProviderAvailable = sync.OnceValue(func() bool {
+	if vMajor == 1 {
+		return false
+	}
 	return isProviderAvailable("symcryptprovider")
 })

--- a/export_test.go
+++ b/export_test.go
@@ -1,3 +1,9 @@
 package openssl
 
+import "sync"
+
 var ErrOpen = errOpen
+
+var SymCryptProviderAvailable = sync.OnceValue(func() bool {
+	return isProviderAvailable("symcryptprovider")
+})

--- a/openssl.go
+++ b/openssl.go
@@ -112,7 +112,7 @@ func FIPS() bool {
 }
 
 // isProviderAvailable checks if the provider with the given name is available.
-// This function is used in export_test.go, as test files can't access C functions.
+// This function is used in export_test.go, but must be defined here as test files can't access C functions.
 func isProviderAvailable(name string) bool {
 	providerName := C.CString(name)
 	defer C.free(unsafe.Pointer(providerName))

--- a/openssl.go
+++ b/openssl.go
@@ -111,6 +111,14 @@ func FIPS() bool {
 	}
 }
 
+// isProviderAvailable checks if the provider with the given name is available.
+// This function is used in export_test.go, as test files can't access C functions.
+func isProviderAvailable(name string) bool {
+	providerName := C.CString(name)
+	defer C.free(unsafe.Pointer(providerName))
+	return C.go_openssl_OSSL_PROVIDER_available(nil, providerName) == 1
+}
+
 // SetFIPS enables or disables FIPS mode.
 //
 // For OpenSSL 3, the `fips` provider is loaded if enabled is true,

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -81,6 +81,10 @@ func TestEncryptDecryptOAEP_EmptyLabel(t *testing.T) {
 }
 
 func TestEncryptDecryptOAEP_WithMGF1Hash(t *testing.T) {
+	if openssl.SymCryptProviderAvailable() {
+		t.Skip("SymCrypt provider does not support MGF1 hash")
+	}
+
 	sha1 := openssl.NewSHA1()
 	sha256 := openssl.NewSHA256()
 	msg := []byte("hi!")
@@ -148,6 +152,10 @@ func TestSignVerifyPKCS1v15(t *testing.T) {
 }
 
 func TestSignVerifyPKCS1v15_Unhashed(t *testing.T) {
+	if openssl.SymCryptProviderAvailable() {
+		t.Skip("SymCrypt provider does not support unhashed PKCS1v15")
+	}
+
 	msg := []byte("hi!")
 	priv, pub := newRSAKey(t, 2048)
 	signed, err := openssl.SignRSAPKCS1v15(priv, 0, msg)


### PR DESCRIPTION
The SymCrypt provider does not currently support RSA encryption with a distinct MGF1 hash function nor using RSA PKCS1.5 with unhashed messages.

This PR skips the affected tests when the SymCrypt provider is available, which means that it will probably be used and the tests will fail.