### PR TITLE
Add implementation of encoding.BinaryAppender for hash algorithms

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -6,7 +6,6 @@ package openssl
 import "C"
 import (
 	"crypto"
-	"encoding/hex"
 	"errors"
 	"hash"
 	"runtime"
@@ -417,16 +416,6 @@ func (h *md5Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	return append(buf, binaryData...), nil
 }
 
-func (h *md5Marshal) AppendText(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
-	hex.Encode(hexData, binaryData)
-	return append(buf, hexData...), nil
-}
-
 // NewSHA1 returns a new SHA1 hash.
 func NewSHA1() hash.Hash {
 	h := sha1Hash{evpHash: newEvpHash(crypto.SHA1)}
@@ -524,16 +513,6 @@ func (h *sha1Marshal) AppendBinary(buf []byte) ([]byte, error) {
 		return nil, err
 	}
 	return append(buf, binaryData...), nil
-}
-
-func (h *sha1Marshal) AppendText(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
-	hex.Encode(hexData, binaryData)
-	return append(buf, hexData...), nil
 }
 
 // NewSHA224 returns a new SHA224 hash.
@@ -731,26 +710,6 @@ func (h *sha256Marshal) AppendBinary(buf []byte) ([]byte, error) {
 		return nil, err
 	}
 	return append(buf, binaryData...), nil
-}
-
-func (h *sha224Marshal) AppendText(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
-	hex.Encode(hexData, binaryData)
-	return append(buf, hexData...), nil
-}
-
-func (h *sha256Marshal) AppendText(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
-	hex.Encode(hexData, binaryData)
-	return append(buf, hexData...), nil
 }
 
 // NewSHA384 returns a new SHA384 hash.
@@ -956,26 +915,6 @@ func (h *sha512Marshal) AppendBinary(buf []byte) ([]byte, error) {
 		return nil, err
 	}
 	return append(buf, binaryData...), nil
-}
-
-func (h *sha384Marshal) AppendText(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
-	hex.Encode(hexData, binaryData)
-	return append(buf, hexData...), nil
-}
-
-func (h *sha512Marshal) AppendText(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
-	hex.Encode(hexData, binaryData)
-	return append(buf, hexData...), nil
 }
 
 // NewSHA3_224 returns a new SHA3-224 hash.

--- a/hash.go
+++ b/hash.go
@@ -408,7 +408,7 @@ func (h *md5Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint32(buf, d.h[2])
 	buf = appendUint32(buf, d.h[3])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
 	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return buf, nil
 }
@@ -462,7 +462,8 @@ type sha1Marshal struct {
 }
 
 func (h *sha1Marshal) MarshalBinary() ([]byte, error) {
-	return h.AppendBinary(nil)
+	buf := make([]byte, 0, sha1MarshaledSize)
+	return h.AppendBinary(buf)
 }
 
 func (h *sha1Marshal) UnmarshalBinary(b []byte) error {
@@ -502,7 +503,7 @@ func (h *sha1Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint32(buf, d.h[3])
 	buf = appendUint32(buf, d.h[4])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
 	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return buf, nil
 }
@@ -671,7 +672,7 @@ func (h *sha224Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint32(buf, d.h[6])
 	buf = appendUint32(buf, d.h[7])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
 	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return buf, nil
 }
@@ -691,7 +692,7 @@ func (h *sha256Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint32(buf, d.h[6])
 	buf = appendUint32(buf, d.h[7])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
 	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return buf, nil
 }
@@ -868,7 +869,7 @@ func (h *sha384Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint64(buf, d.h[6])
 	buf = appendUint64(buf, d.h[7])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
 	buf = appendUint64(buf, d.nl>>3|d.nh<<61)
 	return buf, nil
 }
@@ -888,7 +889,7 @@ func (h *sha512Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint64(buf, d.h[6])
 	buf = appendUint64(buf, d.h[7])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
 	buf = appendUint64(buf, d.nl>>3|d.nh<<61)
 	return buf, nil
 }

--- a/hash.go
+++ b/hash.go
@@ -6,6 +6,7 @@ package openssl
 import "C"
 import (
 	"crypto"
+	"encoding/hex"
 	"errors"
 	"hash"
 	"runtime"
@@ -408,6 +409,24 @@ func (h *md5Marshal) UnmarshalBinary(b []byte) error {
 	return nil
 }
 
+func (h *md5Marshal) AppendBinary(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return append(buf, binaryData...), nil
+}
+
+func (h *md5Marshal) AppendText(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
+	hex.Encode(hexData, binaryData)
+	return append(buf, hexData...), nil
+}
+
 // NewSHA1 returns a new SHA1 hash.
 func NewSHA1() hash.Hash {
 	h := sha1Hash{evpHash: newEvpHash(crypto.SHA1)}
@@ -497,6 +516,24 @@ func (h *sha1Marshal) UnmarshalBinary(b []byte) error {
 	d.nh = uint32(n >> 29)
 	d.nx = uint32(n) % 64
 	return nil
+}
+
+func (h *sha1Marshal) AppendBinary(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return append(buf, binaryData...), nil
+}
+
+func (h *sha1Marshal) AppendText(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
+	hex.Encode(hexData, binaryData)
+	return append(buf, hexData...), nil
 }
 
 // NewSHA224 returns a new SHA224 hash.
@@ -678,6 +715,42 @@ func (h *sha256Marshal) UnmarshalBinary(b []byte) error {
 	d.nh = uint32(n >> 29)
 	d.nx = uint32(n) % 64
 	return nil
+}
+
+func (h *sha224Marshal) AppendBinary(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return append(buf, binaryData...), nil
+}
+
+func (h *sha256Marshal) AppendBinary(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return append(buf, binaryData...), nil
+}
+
+func (h *sha224Marshal) AppendText(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
+	hex.Encode(hexData, binaryData)
+	return append(buf, hexData...), nil
+}
+
+func (h *sha256Marshal) AppendText(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
+	hex.Encode(hexData, binaryData)
+	return append(buf, hexData...), nil
 }
 
 // NewSHA384 returns a new SHA384 hash.
@@ -867,6 +940,42 @@ func (h *sha512Marshal) UnmarshalBinary(b []byte) error {
 	d.nh = n >> 61
 	d.nx = uint32(n) % 128
 	return nil
+}
+
+func (h *sha384Marshal) AppendBinary(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return append(buf, binaryData...), nil
+}
+
+func (h *sha512Marshal) AppendBinary(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return append(buf, binaryData...), nil
+}
+
+func (h *sha384Marshal) AppendText(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
+	hex.Encode(hexData, binaryData)
+	return append(buf, hexData...), nil
+}
+
+func (h *sha512Marshal) AppendText(buf []byte) ([]byte, error) {
+	binaryData, err := h.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	hexData := make([]byte, hex.EncodedLen(len(binaryData)))
+	hex.Encode(hexData, binaryData)
+	return append(buf, hexData...), nil
 }
 
 // NewSHA3_224 returns a new SHA3-224 hash.

--- a/hash.go
+++ b/hash.go
@@ -408,7 +408,7 @@ func (h *md5Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint32(buf, d.h[2])
 	buf = appendUint32(buf, d.h[3])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
 	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return buf, nil
 }
@@ -503,7 +503,7 @@ func (h *sha1Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint32(buf, d.h[3])
 	buf = appendUint32(buf, d.h[4])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
 	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return buf, nil
 }
@@ -672,7 +672,7 @@ func (h *sha224Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint32(buf, d.h[6])
 	buf = appendUint32(buf, d.h[7])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
 	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return buf, nil
 }
@@ -692,7 +692,7 @@ func (h *sha256Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint32(buf, d.h[6])
 	buf = appendUint32(buf, d.h[7])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
 	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
 	return buf, nil
 }
@@ -869,7 +869,7 @@ func (h *sha384Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint64(buf, d.h[6])
 	buf = appendUint64(buf, d.h[7])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
 	buf = appendUint64(buf, d.nl>>3|d.nh<<61)
 	return buf, nil
 }
@@ -889,7 +889,7 @@ func (h *sha512Marshal) AppendBinary(buf []byte) ([]byte, error) {
 	buf = appendUint64(buf, d.h[6])
 	buf = appendUint64(buf, d.h[7])
 	buf = append(buf, d.x[:d.nx]...)
-	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...) // already zero
+	buf = append(buf, make([]byte, len(d.x)-int(d.nx))...)
 	buf = appendUint64(buf, d.nl>>3|d.nh<<61)
 	return buf, nil
 }

--- a/hash.go
+++ b/hash.go
@@ -368,20 +368,8 @@ type md5Marshal struct {
 }
 
 func (h *md5Marshal) MarshalBinary() ([]byte, error) {
-	d := (*md5State)(h.hashState())
-	if d == nil {
-		return nil, errors.New("crypto/md5: can't retrieve hash state")
-	}
-	b := make([]byte, 0, md5MarshaledSize)
-	b = append(b, md5Magic...)
-	b = appendUint32(b, d.h[0])
-	b = appendUint32(b, d.h[1])
-	b = appendUint32(b, d.h[2])
-	b = appendUint32(b, d.h[3])
-	b = append(b, d.x[:d.nx]...)
-	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
-	return b, nil
+	buf := make([]byte, 0, md5MarshaledSize)
+	return h.AppendBinary(buf)
 }
 
 func (h *md5Marshal) UnmarshalBinary(b []byte) error {
@@ -409,11 +397,20 @@ func (h *md5Marshal) UnmarshalBinary(b []byte) error {
 }
 
 func (h *md5Marshal) AppendBinary(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
+	d := (*md5State)(h.hashState())
+	if d == nil {
+		return nil, errors.New("crypto/md5: can't retrieve hash state")
 	}
-	return append(buf, binaryData...), nil
+
+	buf = append(buf, md5Magic...)
+	buf = appendUint32(buf, d.h[0])
+	buf = appendUint32(buf, d.h[1])
+	buf = appendUint32(buf, d.h[2])
+	buf = appendUint32(buf, d.h[3])
+	buf = append(buf, d.x[:d.nx]...)
+	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	return buf, nil
 }
 
 // NewSHA1 returns a new SHA1 hash.
@@ -465,21 +462,7 @@ type sha1Marshal struct {
 }
 
 func (h *sha1Marshal) MarshalBinary() ([]byte, error) {
-	d := (*sha1State)(h.hashState())
-	if d == nil {
-		return nil, errors.New("crypto/sha1: can't retrieve hash state")
-	}
-	b := make([]byte, 0, sha1MarshaledSize)
-	b = append(b, sha1Magic...)
-	b = appendUint32(b, d.h[0])
-	b = appendUint32(b, d.h[1])
-	b = appendUint32(b, d.h[2])
-	b = appendUint32(b, d.h[3])
-	b = appendUint32(b, d.h[4])
-	b = append(b, d.x[:d.nx]...)
-	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
-	return b, nil
+	return h.AppendBinary(nil)
 }
 
 func (h *sha1Marshal) UnmarshalBinary(b []byte) error {
@@ -508,11 +491,20 @@ func (h *sha1Marshal) UnmarshalBinary(b []byte) error {
 }
 
 func (h *sha1Marshal) AppendBinary(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
+	d := (*sha1State)(h.hashState())
+	if d == nil {
+		return nil, errors.New("crypto/sha1: can't retrieve hash state")
 	}
-	return append(buf, binaryData...), nil
+	buf = append(buf, sha1Magic...)
+	buf = appendUint32(buf, d.h[0])
+	buf = appendUint32(buf, d.h[1])
+	buf = appendUint32(buf, d.h[2])
+	buf = appendUint32(buf, d.h[3])
+	buf = appendUint32(buf, d.h[4])
+	buf = append(buf, d.x[:d.nx]...)
+	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	return buf, nil
 }
 
 // NewSHA224 returns a new SHA224 hash.
@@ -599,45 +591,13 @@ type sha256Marshal struct {
 }
 
 func (h *sha224Marshal) MarshalBinary() ([]byte, error) {
-	d := (*sha256State)(h.hashState())
-	if d == nil {
-		return nil, errors.New("crypto/sha256: can't retrieve hash state")
-	}
-	b := make([]byte, 0, marshaledSize256)
-	b = append(b, magic224...)
-	b = appendUint32(b, d.h[0])
-	b = appendUint32(b, d.h[1])
-	b = appendUint32(b, d.h[2])
-	b = appendUint32(b, d.h[3])
-	b = appendUint32(b, d.h[4])
-	b = appendUint32(b, d.h[5])
-	b = appendUint32(b, d.h[6])
-	b = appendUint32(b, d.h[7])
-	b = append(b, d.x[:d.nx]...)
-	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
-	return b, nil
+	buf := make([]byte, 0, marshaledSize256)
+	return h.AppendBinary(buf)
 }
 
 func (h *sha256Marshal) MarshalBinary() ([]byte, error) {
-	d := (*sha256State)(h.hashState())
-	if d == nil {
-		return nil, errors.New("crypto/sha256: can't retrieve hash state")
-	}
-	b := make([]byte, 0, marshaledSize256)
-	b = append(b, magic256...)
-	b = appendUint32(b, d.h[0])
-	b = appendUint32(b, d.h[1])
-	b = appendUint32(b, d.h[2])
-	b = appendUint32(b, d.h[3])
-	b = appendUint32(b, d.h[4])
-	b = appendUint32(b, d.h[5])
-	b = appendUint32(b, d.h[6])
-	b = appendUint32(b, d.h[7])
-	b = append(b, d.x[:d.nx]...)
-	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, uint64(d.nl)>>3|uint64(d.nh)<<29)
-	return b, nil
+	buf := make([]byte, 0, marshaledSize256)
+	return h.AppendBinary(buf)
 }
 
 func (h *sha224Marshal) UnmarshalBinary(b []byte) error {
@@ -697,19 +657,43 @@ func (h *sha256Marshal) UnmarshalBinary(b []byte) error {
 }
 
 func (h *sha224Marshal) AppendBinary(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
+	d := (*sha256State)(h.hashState())
+	if d == nil {
+		return nil, errors.New("crypto/sha256: can't retrieve hash state")
 	}
-	return append(buf, binaryData...), nil
+	buf = append(buf, magic224...)
+	buf = appendUint32(buf, d.h[0])
+	buf = appendUint32(buf, d.h[1])
+	buf = appendUint32(buf, d.h[2])
+	buf = appendUint32(buf, d.h[3])
+	buf = appendUint32(buf, d.h[4])
+	buf = appendUint32(buf, d.h[5])
+	buf = appendUint32(buf, d.h[6])
+	buf = appendUint32(buf, d.h[7])
+	buf = append(buf, d.x[:d.nx]...)
+	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	return buf, nil
 }
 
 func (h *sha256Marshal) AppendBinary(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
+	d := (*sha256State)(h.hashState())
+	if d == nil {
+		return nil, errors.New("crypto/sha256: can't retrieve hash state")
 	}
-	return append(buf, binaryData...), nil
+	buf = append(buf, magic256...)
+	buf = appendUint32(buf, d.h[0])
+	buf = appendUint32(buf, d.h[1])
+	buf = appendUint32(buf, d.h[2])
+	buf = appendUint32(buf, d.h[3])
+	buf = appendUint32(buf, d.h[4])
+	buf = appendUint32(buf, d.h[5])
+	buf = appendUint32(buf, d.h[6])
+	buf = appendUint32(buf, d.h[7])
+	buf = append(buf, d.x[:d.nx]...)
+	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = appendUint64(buf, uint64(d.nl)>>3|uint64(d.nh)<<29)
+	return buf, nil
 }
 
 // NewSHA384 returns a new SHA384 hash.
@@ -798,45 +782,13 @@ type sha512Marshal struct {
 }
 
 func (h *sha384Marshal) MarshalBinary() ([]byte, error) {
-	d := (*sha512State)(h.hashState())
-	if d == nil {
-		return nil, errors.New("crypto/sha512: can't retrieve hash state")
-	}
-	b := make([]byte, 0, marshaledSize512)
-	b = append(b, magic384...)
-	b = appendUint64(b, d.h[0])
-	b = appendUint64(b, d.h[1])
-	b = appendUint64(b, d.h[2])
-	b = appendUint64(b, d.h[3])
-	b = appendUint64(b, d.h[4])
-	b = appendUint64(b, d.h[5])
-	b = appendUint64(b, d.h[6])
-	b = appendUint64(b, d.h[7])
-	b = append(b, d.x[:d.nx]...)
-	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, d.nl>>3|d.nh<<61)
-	return b, nil
+	buf := make([]byte, 0, marshaledSize512)
+	return h.AppendBinary(buf)
 }
 
 func (h *sha512Marshal) MarshalBinary() ([]byte, error) {
-	d := (*sha512State)(h.hashState())
-	if d == nil {
-		return nil, errors.New("crypto/sha512: can't retrieve hash state")
-	}
-	b := make([]byte, 0, marshaledSize512)
-	b = append(b, magic512...)
-	b = appendUint64(b, d.h[0])
-	b = appendUint64(b, d.h[1])
-	b = appendUint64(b, d.h[2])
-	b = appendUint64(b, d.h[3])
-	b = appendUint64(b, d.h[4])
-	b = appendUint64(b, d.h[5])
-	b = appendUint64(b, d.h[6])
-	b = appendUint64(b, d.h[7])
-	b = append(b, d.x[:d.nx]...)
-	b = b[:len(b)+len(d.x)-int(d.nx)] // already zero
-	b = appendUint64(b, d.nl>>3|d.nh<<61)
-	return b, nil
+	buf := make([]byte, 0, marshaledSize512)
+	return h.AppendBinary(buf)
 }
 
 func (h *sha384Marshal) UnmarshalBinary(b []byte) error {
@@ -902,19 +854,43 @@ func (h *sha512Marshal) UnmarshalBinary(b []byte) error {
 }
 
 func (h *sha384Marshal) AppendBinary(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
+	d := (*sha512State)(h.hashState())
+	if d == nil {
+		return nil, errors.New("crypto/sha512: can't retrieve hash state")
 	}
-	return append(buf, binaryData...), nil
+	buf = append(buf, magic384...)
+	buf = appendUint64(buf, d.h[0])
+	buf = appendUint64(buf, d.h[1])
+	buf = appendUint64(buf, d.h[2])
+	buf = appendUint64(buf, d.h[3])
+	buf = appendUint64(buf, d.h[4])
+	buf = appendUint64(buf, d.h[5])
+	buf = appendUint64(buf, d.h[6])
+	buf = appendUint64(buf, d.h[7])
+	buf = append(buf, d.x[:d.nx]...)
+	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = appendUint64(buf, d.nl>>3|d.nh<<61)
+	return buf, nil
 }
 
 func (h *sha512Marshal) AppendBinary(buf []byte) ([]byte, error) {
-	binaryData, err := h.MarshalBinary()
-	if err != nil {
-		return nil, err
+	d := (*sha512State)(h.hashState())
+	if d == nil {
+		return nil, errors.New("crypto/sha512: can't retrieve hash state")
 	}
-	return append(buf, binaryData...), nil
+	buf = append(buf, magic512...)
+	buf = appendUint64(buf, d.h[0])
+	buf = appendUint64(buf, d.h[1])
+	buf = appendUint64(buf, d.h[2])
+	buf = appendUint64(buf, d.h[3])
+	buf = appendUint64(buf, d.h[4])
+	buf = appendUint64(buf, d.h[5])
+	buf = appendUint64(buf, d.h[6])
+	buf = appendUint64(buf, d.h[7])
+	buf = append(buf, d.x[:d.nx]...)
+	buf = buf[:len(buf)+len(d.x)-int(d.nx)] // already zero
+	buf = appendUint64(buf, d.nl>>3|d.nh<<61)
+	return buf, nil
 }
 
 // NewSHA3_224 returns a new SHA3-224 hash.

--- a/hash_test.go
+++ b/hash_test.go
@@ -77,85 +77,23 @@ func TestHash(t *testing.T) {
 			if bytes.Equal(sum, initSum) {
 				t.Error("Write didn't change internal hash state")
 			}
+			if _, ok := h.(encoding.BinaryMarshaler); ok {
+				state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
+				if err != nil {
+					t.Errorf("could not marshal: %v", err)
+				}
+				h2 := cryptoToHash(ch)()
+				if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
+					t.Errorf("could not unmarshal: %v", err)
+				}
+				if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
+					t.Errorf("0x%x != marshaled 0x%x", actual, actual2)
+				}
+			}
 			h.Reset()
 			sum = h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {
 				t.Errorf("got:%x want:%x", sum, initSum)
-			}
-		})
-	}
-}
-
-func TestHash_BinaryMarshaler(t *testing.T) {
-	msg := []byte("testing")
-	for _, ch := range hashes {
-		t.Run(ch.String(), func(t *testing.T) {
-			t.Parallel()
-			if !openssl.SupportsHash(ch) {
-				t.Skip("skipping: not supported")
-			}
-			h := cryptoToHash(ch)()
-			if _, ok := h.(encoding.BinaryMarshaler); !ok {
-				t.Skip("skipping: not supported")
-			}
-			_, err := h.Write(msg)
-			if err != nil {
-				t.Fatal(err)
-			}
-			state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
-			if err != nil {
-				t.Errorf("could not marshal: %v", err)
-			}
-			h2 := cryptoToHash(ch)()
-			if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
-				t.Errorf("could not unmarshal: %v", err)
-			}
-			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
-				t.Errorf("0x%x != marshaled 0x%x", actual, actual2)
-			}
-		})
-	}
-}
-
-func TestHash_Clone(t *testing.T) {
-	msg := []byte("testing")
-	for _, ch := range hashes {
-		t.Run(ch.String(), func(t *testing.T) {
-			t.Parallel()
-			if !openssl.SupportsHash(ch) {
-				t.Skip("skipping: not supported")
-			}
-			h := cryptoToHash(ch)()
-			if _, ok := h.(encoding.BinaryMarshaler); !ok {
-				t.Skip("skipping: not supported")
-			}
-			_, err := h.Write(msg)
-			if err != nil {
-				t.Fatal(err)
-			}
-			// We don't define an interface for the Clone method to avoid other
-			// packages from depending on it. Use type assertion to call it.
-			h2, err := h.(interface{ Clone() (hash.Hash, error) }).Clone()
-			if err != nil {
-				t.Fatal(err)
-			}
-			h.Write(msg)
-			h2.Write(msg)
-			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
-				t.Errorf("%s(%q) = 0x%x != cloned 0x%x", ch.String(), msg, actual, actual2)
-			}
-		})
-	}
-}
-
-func TestHash_ByteWriter(t *testing.T) {
-	msg := []byte("testing")
-	for _, ch := range hashes {
-		ch := ch
-		t.Run(ch.String(), func(t *testing.T) {
-			t.Parallel()
-			if !openssl.SupportsHash(ch) {
-				t.Skip("skipping: not supported")
 			}
 			h := cryptoToHash(ch)()
 			initSum := h.Sum(nil)

--- a/hash_test.go
+++ b/hash_test.go
@@ -117,7 +117,7 @@ func TestHash_BinaryMarshaler(t *testing.T) {
 	}
 }
 
-func TesHash_BinaryAppender(t *testing.T) {
+func TestHash_BinaryAppender(t *testing.T) {
 	for _, ch := range hashes {
 		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
@@ -160,6 +160,8 @@ func TesHash_BinaryAppender(t *testing.T) {
 				if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
 					t.Errorf("0x%x != appended 0x%x", actual, actual2)
 				}
+			} else {
+				t.Skip("skipping: not supported")
 			}
 		})
 	}

--- a/hash_test.go
+++ b/hash_test.go
@@ -77,23 +77,85 @@ func TestHash(t *testing.T) {
 			if bytes.Equal(sum, initSum) {
 				t.Error("Write didn't change internal hash state")
 			}
-			if _, ok := h.(encoding.BinaryMarshaler); ok {
-				state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
-				if err != nil {
-					t.Errorf("could not marshal: %v", err)
-				}
-				h2 := cryptoToHash(ch)()
-				if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
-					t.Errorf("could not unmarshal: %v", err)
-				}
-				if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
-					t.Errorf("0x%x != marshaled 0x%x", actual, actual2)
-				}
-			}
 			h.Reset()
 			sum = h.Sum(nil)
 			if !bytes.Equal(sum, initSum) {
 				t.Errorf("got:%x want:%x", sum, initSum)
+			}
+		})
+	}
+}
+
+func TestHash_BinaryMarshaler(t *testing.T) {
+	msg := []byte("testing")
+	for _, ch := range hashes {
+		t.Run(ch.String(), func(t *testing.T) {
+			t.Parallel()
+			if !openssl.SupportsHash(ch) {
+				t.Skip("skipping: not supported")
+			}
+			h := cryptoToHash(ch)()
+			if _, ok := h.(encoding.BinaryMarshaler); !ok {
+				t.Skip("skipping: not supported")
+			}
+			_, err := h.Write(msg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			state, err := h.(encoding.BinaryMarshaler).MarshalBinary()
+			if err != nil {
+				t.Errorf("could not marshal: %v", err)
+			}
+			h2 := cryptoToHash(ch)()
+			if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(state); err != nil {
+				t.Errorf("could not unmarshal: %v", err)
+			}
+			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
+				t.Errorf("0x%x != marshaled 0x%x", actual, actual2)
+			}
+		})
+	}
+}
+
+func TestHash_Clone(t *testing.T) {
+	msg := []byte("testing")
+	for _, ch := range hashes {
+		t.Run(ch.String(), func(t *testing.T) {
+			t.Parallel()
+			if !openssl.SupportsHash(ch) {
+				t.Skip("skipping: not supported")
+			}
+			h := cryptoToHash(ch)()
+			if _, ok := h.(encoding.BinaryMarshaler); !ok {
+				t.Skip("skipping: not supported")
+			}
+			_, err := h.Write(msg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// We don't define an interface for the Clone method to avoid other
+			// packages from depending on it. Use type assertion to call it.
+			h2, err := h.(interface{ Clone() (hash.Hash, error) }).Clone()
+			if err != nil {
+				t.Fatal(err)
+			}
+			h.Write(msg)
+			h2.Write(msg)
+			if actual, actual2 := h.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {
+				t.Errorf("%s(%q) = 0x%x != cloned 0x%x", ch.String(), msg, actual, actual2)
+			}
+		})
+	}
+}
+
+func TestHash_ByteWriter(t *testing.T) {
+	msg := []byte("testing")
+	for _, ch := range hashes {
+		ch := ch
+		t.Run(ch.String(), func(t *testing.T) {
+			t.Parallel()
+			if !openssl.SupportsHash(ch) {
+				t.Skip("skipping: not supported")
 			}
 			h := cryptoToHash(ch)()
 			initSum := h.Sum(nil)


### PR DESCRIPTION
This PR resolves issue #148 by implementing the encoding.BinaryAppender interface for our hash functions. In Go 1.24, all hash algorithms are expected to implement this interface, as outlined in the following changeset: [crypto: implement encoding.BinaryAppender for all crypto hashes](https://go-review.googlesource.com/c/go/+/601776).

By adding this interface implementation to our fork, we ensure compatibility with the upcoming Go 1.24 release and future-proof our codebase against breaking changes related to the handling of binary encoding for hash algorithms.