### PR TITLE
Fix: Loop Variable Capturing Issue in Go 1.22

### DIFF
--- a/hash_test.go
+++ b/hash_test.go
@@ -56,7 +56,6 @@ var hashes = [...]crypto.Hash{
 func TestHash(t *testing.T) {
 	msg := []byte("testing")
 	for _, ch := range hashes {
-		ch := ch
 		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
 			if !openssl.SupportsHash(ch) {
@@ -90,7 +89,6 @@ func TestHash(t *testing.T) {
 func TestHash_BinaryMarshaler(t *testing.T) {
 	msg := []byte("testing")
 	for _, ch := range hashes {
-		ch := ch
 		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
 			if !openssl.SupportsHash(ch) {
@@ -122,7 +120,6 @@ func TestHash_BinaryMarshaler(t *testing.T) {
 func TestHash_Clone(t *testing.T) {
 	msg := []byte("testing")
 	for _, ch := range hashes {
-		ch := ch
 		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
 			if !openssl.SupportsHash(ch) {

--- a/hash_test.go
+++ b/hash_test.go
@@ -160,7 +160,7 @@ func TestHash_ByteWriter(t *testing.T) {
 			h := cryptoToHash(ch)()
 			initSum := h.Sum(nil)
 			bw := h.(io.ByteWriter)
-			for i := 0; i < len(msg); i++ {
+			for i := range len(msg) {
 				bw.WriteByte(msg[i])
 			}
 			h.Reset()

--- a/hkdf_test.go
+++ b/hkdf_test.go
@@ -350,7 +350,7 @@ func TestHKDFMultiRead(t *testing.T) {
 		hkdf := newHKDF(tt.hash, tt.master, tt.salt, tt.info)
 		out := make([]byte, len(tt.out))
 
-		for b := 0; b < len(tt.out); b++ {
+		for b := range len(tt.out) {
 			n, err := io.ReadFull(hkdf, out[b:b+1])
 			if n != 1 || err != nil {
 				t.Errorf("test %d.%d: not enough output bytes: have %d, need %d .", i, b, n, len(tt.out))

--- a/hmac_test.go
+++ b/hmac_test.go
@@ -18,7 +18,6 @@ func TestHMAC(t *testing.T) {
 		{"sha512", NewSHA512},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			h := NewHMAC(tt.fn, nil)

--- a/openssl.go
+++ b/openssl.go
@@ -298,7 +298,7 @@ const wordBytes = bits.UintSize / 8
 func (z BigInt) byteSwap() {
 	for i, d := range z {
 		var n uint = 0
-		for j := 0; j < wordBytes; j++ {
+		for j := range wordBytes {
 			n |= uint(byte(d)) << (8 * (wordBytes - j - 1))
 			d >>= 8
 		}
@@ -400,7 +400,7 @@ func bnToBinPad(bn C.GO_BIGNUM_PTR, to []byte) error {
 		if pad < 0 {
 			return errors.New("openssl: destination buffer too small")
 		}
-		for i := 0; i < pad; i++ {
+		for i := range pad {
 			to[i] = 0
 		}
 		if int(C.go_openssl_BN_bn2bin(bn, base(to[pad:]))) != n {

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 	fmt.Println("OpenSSL version:", openssl.VersionText())
 	fmt.Println("FIPS enabled:", openssl.FIPS())
 	status := m.Run()
-	for _ = range 5 {
+	for range 5 {
 		// Run GC a few times to avoid false positives in leak detection.
 		runtime.GC()
 		// Sleep a bit to let the finalizers run.

--- a/openssl_test.go
+++ b/openssl_test.go
@@ -58,7 +58,7 @@ func TestMain(m *testing.M) {
 	fmt.Println("OpenSSL version:", openssl.VersionText())
 	fmt.Println("FIPS enabled:", openssl.FIPS())
 	status := m.Run()
-	for i := 0; i < 5; i++ {
+	for _ = range 5 {
 		// Run GC a few times to avoid false positives in leak detection.
 		runtime.GC()
 		// Sleep a bit to let the finalizers run.

--- a/rsa_test.go
+++ b/rsa_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestRSAKeyGeneration(t *testing.T) {
 	for _, size := range []int{2048, 3072} {
-		size := size
 		t.Run(strconv.Itoa(size), func(t *testing.T) {
 			t.Parallel()
 			priv, pub := newRSAKey(t, size)

--- a/tls1prf_test.go
+++ b/tls1prf_test.go
@@ -150,7 +150,6 @@ func TestTLS1PRF(t *testing.T) {
 		t.Skip("TLS PRF is not supported")
 	}
 	for _, tt := range tls1prfTests {
-		tt := tt
 		t.Run(tt.hash.String(), func(t *testing.T) {
 			if !openssl.SupportsHash(tt.hash) {
 				t.Skip("skipping: hash not supported")


### PR DESCRIPTION
This pull request addresses an issue with loop variable capturing that was resolved in Go 1.22. Prior to Go 1.22, closures within loops would capture the loop variable itself, leading to unexpected behavior due to the variable's value changing by the time the closure was executed.

Changes Made:
Updated code to align with the new behavior in Go 1.22, where the loop variable's value is captured at each iteration rather than the variable itself.