### PR TITLE
Fix TestHMAC when using the SymCrypt provider

### DIFF
--- a/hmac_test.go
+++ b/hmac_test.go
@@ -21,6 +21,9 @@ func TestHMAC(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			h := NewHMAC(tt.fn, nil)
+			if h == nil {
+				t.Skip("digest not supported")
+			}
 			h.Write([]byte("hello"))
 			sumHello := h.Sum(nil)
 


### PR DESCRIPTION
In #159 I missed to update `TestHMAC` so the test was skipped when `NewHMAC` returned nil. This PR corrects that.

Note that I wasn't catch by CI because Azure Linux 3 tests failures still don't block PRs.