### PR TITLE
Fail CI pipeline if azurelinux job fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,3 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Run Test
       run: go test -v ./...
-      # Go with FIPs / OpenSSL support on Azure Linux 3.0 is currently broken due to symcrypt change, so we ignore failures.
-      # See https://github.com/golang-fips/openssl/issues/158.
-      continue-on-error: true 


### PR DESCRIPTION
All tests are passing when executed on Azure Linux 3: https://github.com/golang-fips/openssl/actions/runs/10793057985 🥳 

We now promote it to first-class target by blocking PRs if the `azurelinux` job fails.