### PR TITLE
Remove multiple interface conversions in tests

### DIFF
--- a/hash_test.go
+++ b/hash_test.go
@@ -59,7 +59,7 @@ func TestHash(t *testing.T) {
 		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
 			if !openssl.SupportsHash(ch) {
-				t.Skip("skipping: not supported")
+				t.Skip("not supported")
 			}
 			h := cryptoToHash(ch)()
 			initSum := h.Sum(nil)
@@ -132,7 +132,7 @@ func TestHash_BinaryAppender(t *testing.T) {
 		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
 			if !openssl.SupportsHash(ch) {
-				t.Skip("skipping: not supported")
+				t.Skip("not supported")
 			}
 
 			hashWithBinaryAppender, ok := cryptoToHash(ch)().(interface {
@@ -140,7 +140,7 @@ func TestHash_BinaryAppender(t *testing.T) {
 				AppendBinary(b []byte) ([]byte, error)
 			})
 			if !ok {
-				t.Skip("skipping: not supported")
+				t.Skip("not supported")
 			}
 
 			// Create a slice with 10 elements
@@ -184,11 +184,11 @@ func TestHash_Clone(t *testing.T) {
 		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
 			if !openssl.SupportsHash(ch) {
-				t.Skip("skipping: not supported")
+				t.Skip("not supported")
 			}
 			h := cryptoToHash(ch)()
 			if _, ok := h.(encoding.BinaryMarshaler); !ok {
-				t.Skip("skipping: not supported")
+				t.Skip("not supported")
 			}
 			_, err := h.Write(msg)
 			if err != nil {
@@ -215,7 +215,7 @@ func TestHash_ByteWriter(t *testing.T) {
 		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
 			if !openssl.SupportsHash(ch) {
-				t.Skip("skipping: not supported")
+				t.Skip("not supported")
 			}
 			bwh := cryptoToHash(ch)().(interface {
 				hash.Hash
@@ -240,7 +240,7 @@ func TestHash_StringWriter(t *testing.T) {
 		t.Run(ch.String(), func(t *testing.T) {
 			t.Parallel()
 			if !openssl.SupportsHash(ch) {
-				t.Skip("skipping: not supported")
+				t.Skip("not supported")
 			}
 			h := cryptoToHash(ch)()
 			initSum := h.Sum(nil)
@@ -300,7 +300,7 @@ func TestHash_OneShot(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.h.String(), func(t *testing.T) {
 			if !openssl.SupportsHash(tt.h) {
-				t.Skip("skipping: not supported")
+				t.Skip("not supported")
 			}
 			got := tt.oneShot(msg)
 			h := cryptoToHash(tt.h)()

--- a/hash_test.go
+++ b/hash_test.go
@@ -167,8 +167,15 @@ func TestHash_BinaryAppender(t *testing.T) {
 			// Use only the newly appended part of the slice
 			appendedState := state[10:]
 
-			h2 := cryptoToHash(ch)()
-			if err := h2.(encoding.BinaryUnmarshaler).UnmarshalBinary(appendedState); err != nil {
+			h2, ok := cryptoToHash(ch)().(interface {
+				hash.Hash
+				encoding.BinaryUnmarshaler
+			})
+			if !ok {
+				t.Skip("not supported")
+			}
+
+			if err := h2.UnmarshalBinary(appendedState); err != nil {
 				t.Errorf("could not unmarshal: %v", err)
 			}
 			if actual, actual2 := hashWithBinaryAppender.Sum(nil), h2.Sum(nil); !bytes.Equal(actual, actual2) {


### PR DESCRIPTION
Simplify tests with removing extra conversions and reducing the variable declarations.
Also removing the "skipped:" prefix, since we already calling t.Skip(), we don't need to implement this.