### PR TITLE
 Refactor RandReader Implementation

### DIFF
--- a/dsa_test.go
+++ b/dsa_test.go
@@ -111,7 +111,7 @@ func testDSASignAndVerify(t *testing.T, priv *openssl.PrivateKeyDSA) {
 	if !dsa.Verify(&priv1.PublicKey, hashed[:], esig.R, esig.S) {
 		t.Error("compat: crypto/dsa can't verify OpenSSL signature")
 	}
-	r1, s1, err := dsa.Sign(openssl.RandReader, &priv1, hashed[:])
+	r1, s1, err := dsa.Sign(openssl.NewRandReader(), &priv1, hashed[:])
 	if err != nil {
 		t.Errorf("error signing: %s", err)
 		return

--- a/rand.go
+++ b/rand.go
@@ -4,14 +4,11 @@ package openssl
 
 // #include "goopenssl.h"
 import "C"
-import (
-	"io"
-	"unsafe"
-)
+import "unsafe"
 
-type randReader struct{}
+type RandReader struct{}
 
-func (randReader) Read(b []byte) (int, error) {
+func (RandReader) Read(b []byte) (int, error) {
 	// Note: RAND_bytes should never fail; the return value exists only for historical reasons.
 	// We check it even so.
 	if len(b) > 0 && C.go_openssl_RAND_bytes((*C.uchar)(unsafe.Pointer(&b[0])), C.int(len(b))) == 0 {
@@ -20,6 +17,6 @@ func (randReader) Read(b []byte) (int, error) {
 	return len(b), nil
 }
 
-func NewRandReader() io.Reader {
-	return randReader{}
+func NewRandReader() RandReader {
+	return RandReader{}
 }

--- a/rand.go
+++ b/rand.go
@@ -4,9 +4,12 @@ package openssl
 
 // #include "goopenssl.h"
 import "C"
-import "unsafe"
+import (
+	"io"
+	"unsafe"
+)
 
-type randReader int
+type randReader struct{}
 
 func (randReader) Read(b []byte) (int, error) {
 	// Note: RAND_bytes should never fail; the return value exists only for historical reasons.
@@ -17,4 +20,6 @@ func (randReader) Read(b []byte) (int, error) {
 	return len(b), nil
 }
 
-const RandReader = randReader(0)
+func NewRandReader() io.Reader {
+	return randReader{}
+}

--- a/rand_test.go
+++ b/rand_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRand(t *testing.T) {
-	_, err := openssl.RandReader.Read(make([]byte, 5))
+	_, err := openssl.NewRandReader().Read(make([]byte, 5))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Changes
-Changed randReader from int to struct{}.
   -Semantic clarity: Clearly indicates the type doesn't need to hold state.
   -Consistency: Aligns with Go conventions for types that only need methods. (for example: io.Discard)
-Replaced global RandReader variable with NewRandReader() function.
