### PR TITLE
Implement SupportsDSA

### DIFF
--- a/dsa.go
+++ b/dsa.go
@@ -17,6 +17,16 @@ var (
 	OSSL_PKEY_PARAM_FFC_G     = C.CString("g")
 )
 
+// SupportsDSA returns true if the OpenSSL library supports DSA.
+func SupportsDSA() bool {
+	ctx := C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_DSA, nil)
+	if ctx == nil {
+		return false
+	}
+	C.go_openssl_EVP_PKEY_CTX_free(ctx)
+	return true
+}
+
 // DSAParameters contains the DSA parameters.
 type DSAParameters struct {
 	P, Q, G BigInt

--- a/dsa_test.go
+++ b/dsa_test.go
@@ -16,6 +16,10 @@ type dsaSignature struct {
 }
 
 func TestDSAGenerateParameters(t *testing.T) {
+	if !openssl.SupportsDSA() {
+		t.Skip("DSA is not supported")
+	}
+
 	var tests = []struct {
 		L, N int
 	}{
@@ -128,9 +132,13 @@ func testDSASignAndVerify(t *testing.T, priv *openssl.PrivateKeyDSA) {
 }
 
 func TestDSASignAndVerify(t *testing.T) {
+	if !openssl.SupportsDSA() {
+		t.Skip("DSA is not supported")
+	}
 	if openssl.FIPS() {
 		t.Skip("DSA signing with L = 2048 is not supported in FIPS mode")
 	}
+
 	params := openssl.DSAParameters{
 		P: bbig.Enc(fromHex("A9B5B793FB4785793D246BAE77E8FF63CA52F442DA763C440259919FE1BC1D6065A9350637A04F75A2F039401D49F08E066C4D275A5A65DA5684BC563C14289D7AB8A67163BFBF79D85972619AD2CFF55AB0EE77A9002B0EF96293BDD0F42685EBB2C66C327079F6C98000FBCB79AACDE1BC6F9D5C7B1A97E3D9D54ED7951FEF")),
 		Q: bbig.Enc(fromHex("E1D3391245933D68A0714ED34BBCB7A1F422B9C1")),
@@ -147,6 +155,10 @@ func TestDSASignAndVerify(t *testing.T) {
 }
 
 func TestDSANewPrivateKeyWithDegenerateKeys(t *testing.T) {
+	if !openssl.SupportsDSA() {
+		t.Skip("DSA is not supported")
+	}
+
 	// Signing with degenerate private keys should not cause an infinite loop
 	badKeys := []struct {
 		p, q, g, y, x string
@@ -175,6 +187,10 @@ func TestDSANewPrivateKeyWithDegenerateKeys(t *testing.T) {
 }
 
 func TestDSANewPublicKeyWithBadPublicKey(t *testing.T) {
+	if !openssl.SupportsDSA() {
+		t.Skip("DSA is not supported")
+	}
+
 	params := openssl.DSAParameters{
 		P: bbig.Enc(fromHex("A9B5B793FB4785793D246BAE77E8FF63CA52F442DA763C440259919FE1BC1D6065A9350637A04F75A2F039401D49F08E066C4D275A5A65DA5684BC563C14289D7AB8A67163BFBF79D85972619AD2CFF55AB0EE77A9002B0EF96293BDD0F42685EBB2C66C327079F6C98000FBCB79AACDE1BC6F9D5C7B1A97E3D9D54ED7951FEF")),
 		Q: bbig.Enc(fromHex("FA")),


### PR DESCRIPTION
Some provider, such as SymCrypt, doesn't support DSA.

This PR implements the `openssl.SupportsDSA` function so callers can check if it is supported or not. Also, use it in the DSA tests.