### PR TITLE
Make SupportsHKDF provider-aware

### DIFF
--- a/hkdf.go
+++ b/hkdf.go
@@ -13,7 +13,12 @@ import (
 )
 
 func SupportsHKDF() bool {
-	return versionAtOrAbove(1, 1, 1)
+	ctx := C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_HKDF, nil)
+	if ctx == nil {
+		return false
+	}
+	C.go_openssl_EVP_PKEY_CTX_free(ctx)
+	return false
 }
 
 func newHKDF(h func() hash.Hash, mode C.int) (*hkdf, error) {


### PR DESCRIPTION
Some provider (such as SymCrypt) doesn't support HKDF via the `EVP_PKEY` API but via the [EVP_KDF-HKDF](https://docs.openssl.org/master/man7/EVP_KDF-HKDF) API. In theory the `EVP_KDF-HKDF` API should have deprecated the `EVP-PKEY` API for all KDF-related algorithms, but the built-in provider still support it to keep backwards compatibility.

Switching our OpenSSL 3 HKDF implementation is a major task, so for now just make  `openssl.SupportsHKDF` aware that some providers might not implement the current approach.