### PR TITLE
Implement TLS1 PRF using the EVP_KDF API in OpenSSL 3

### DIFF
--- a/params.go
+++ b/params.go
@@ -73,9 +73,9 @@ func (b *paramBuilder) build() (C.GO_OSSL_PARAM_PTR, error) {
 	return param, nil
 }
 
-// addUtf8String adds a UTF-8 string to the builder.
+// addUTF8String adds a UTF-8 string to the builder.
 // size should not include the terminating NUL byte. If it is zero then it will be calculated.
-func (b *paramBuilder) addUtf8String(name *C.char, value *C.char, size C.size_t) {
+func (b *paramBuilder) addUTF8String(name *C.char, value *C.char, size C.size_t) {
 	if !b.check() {
 		return
 	}

--- a/params.go
+++ b/params.go
@@ -1,0 +1,99 @@
+//go:build !cmd_go_bootstrap
+
+package openssl
+
+// #include "goopenssl.h"
+import "C"
+import (
+	"runtime"
+	"unsafe"
+)
+
+var (
+	// KDF parameters
+	_OSSL_KDF_PARAM_DIGEST = C.CString("digest")
+	_OSSL_KDF_PARAM_SECRET = C.CString("secret")
+	_OSSL_KDF_PARAM_SEED   = C.CString("seed")
+)
+
+// paramBuilder is a helper for building OSSL_PARAMs.
+// If an error occurs when adding a new parameter,
+// subsequent calls to add parameters are ignored
+// and build() will return the error.
+type paramBuilder struct {
+	bld    C.GO_OSSL_PARAM_BLD_PTR
+	pinner runtime.Pinner
+
+	err error
+}
+
+// newParamBuilder creates a new paramBuilder.
+func newParamBuilder() (*paramBuilder, error) {
+	bld := C.go_openssl_OSSL_PARAM_BLD_new()
+	if bld == nil {
+		return nil, newOpenSSLError("OSSL_PARAM_BLD_new")
+	}
+	pb := &paramBuilder{bld: bld}
+	runtime.SetFinalizer(pb, (*paramBuilder).finalize)
+	return pb, nil
+}
+
+// free frees the builder.
+func (b *paramBuilder) finalize() {
+	if b.bld != nil {
+		b.pinner.Unpin()
+		C.go_openssl_OSSL_PARAM_BLD_free(b.bld)
+		b.bld = nil
+	}
+}
+
+func (b *paramBuilder) check() bool {
+	if b.err != nil {
+		return false
+	}
+	if b.bld == nil {
+		panic("openssl: paramBuilder has been freed")
+	}
+	return true
+}
+
+// build creates an OSSL_PARAM from the builder.
+// The returned OSSL_PARAM must be freed with OSSL_PARAM_free.
+// If an error occurred during building, it is returned.
+// The builder is freed and cannot be reused.
+func (b *paramBuilder) build() (C.GO_OSSL_PARAM_PTR, error) {
+	if !b.check() {
+		return nil, b.err
+	}
+	param := C.go_openssl_OSSL_PARAM_BLD_to_param(b.bld)
+	if param == nil {
+		return nil, newOpenSSLError("OSSL_PARAM_BLD_build")
+	}
+	b.finalize() // we shouldn't reuse the builder once we've built the params
+	return param, nil
+}
+
+// addUtf8String adds a UTF-8 string to the builder.
+// size should not include the terminating NUL byte. If it is zero then it will be calculated.
+func (b *paramBuilder) addUtf8String(name *C.char, value *C.char, size C.size_t) {
+	if !b.check() {
+		return
+	}
+	if C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(b.bld, name, value, size) != 1 {
+		b.err = newOpenSSLError("OSSL_PARAM_BLD_push_utf8_string(" + C.GoString(name) + ")")
+	}
+}
+
+// addOctetString adds an octet string to the builder.
+// The value is pinned and will be unpinned when the builder is freed.
+func (b *paramBuilder) addOctetString(name *C.char, value []byte) {
+	if !b.check() {
+		return
+	}
+	if len(value) != 0 {
+		b.pinner.Pin(&value[0])
+	}
+	if C.go_openssl_OSSL_PARAM_BLD_push_octet_string(b.bld, name, unsafe.Pointer(sbase(value)), C.size_t(len(value))) != 1 {
+		b.err = newOpenSSLError("OSSL_PARAM_BLD_push_octet_string(" + C.GoString(name) + ")")
+	}
+}

--- a/params.go
+++ b/params.go
@@ -75,16 +75,16 @@ func (b *paramBuilder) build() (C.GO_OSSL_PARAM_PTR, error) {
 	if param == nil {
 		return nil, newOpenSSLError("OSSL_PARAM_BLD_build")
 	}
-	b.finalize() // we shouldn't reuse the builder once we've built the params
 	return param, nil
 }
 
-// addUTF8String adds a UTF-8 string to the builder.
-// size should not include the terminating NUL byte. If it is zero then it will be calculated.
+// addUTF8String adds a NUL-terminated UTF-8 string to the builder.
+// size should not include the terminating NUL byte. If size is zero, then it will be calculated.
 func (b *paramBuilder) addUTF8String(name *C.char, value *C.char, size C.size_t) {
 	if !b.check() {
 		return
 	}
+	// OSSL_PARAM_BLD_push_utf8_string calculates the size if it is zero.
 	if C.go_openssl_OSSL_PARAM_BLD_push_utf8_string(b.bld, name, value, size) != 1 {
 		b.err = newOpenSSLError("OSSL_PARAM_BLD_push_utf8_string(" + C.GoString(name) + ")")
 	}

--- a/params.go
+++ b/params.go
@@ -59,9 +59,11 @@ func (b *paramBuilder) check() bool {
 
 // build creates an OSSL_PARAM from the builder.
 // The returned OSSL_PARAM must be freed with OSSL_PARAM_free.
-// If an error occurred during building, it is returned.
-// The builder is freed and cannot be reused.
+// If an error occurred while adding parameters, the error is returned
+// and the OSSL_PARAM is nil. Once build() is called, the builder is finalized
+// and cannot be reused.
 func (b *paramBuilder) build() (C.GO_OSSL_PARAM_PTR, error) {
+	defer b.finalize()
 	if !b.check() {
 		return nil, b.err
 	}

--- a/params.go
+++ b/params.go
@@ -38,7 +38,7 @@ func newParamBuilder() (*paramBuilder, error) {
 	return pb, nil
 }
 
-// free frees the builder.
+// finalize frees the builder.
 func (b *paramBuilder) finalize() {
 	if b.bld != nil {
 		b.pinner.Unpin()
@@ -47,6 +47,10 @@ func (b *paramBuilder) finalize() {
 	}
 }
 
+// check is used internally to enforce invariants and should not be called by users of paramBuilder.
+// Returns true if it's ok to add parameters to the builder or build it.
+// Returns false if there has been an error while adding a parameter.
+// Panics if the paramBuilder has been freed, e.g. if it has already been built.
 func (b *paramBuilder) check() bool {
 	if b.err != nil {
 		return false

--- a/shims.h
+++ b/shims.h
@@ -109,7 +109,6 @@ typedef void* GO_DSA_PTR;
 typedef void* GO_EVP_KDF_PTR;
 typedef void* GO_EVP_KDF_CTX_PTR;
 
-
 // #include <openssl/md5.h>
 typedef void* GO_MD5_CTX_PTR;
 

--- a/shims.h
+++ b/shims.h
@@ -106,6 +106,9 @@ typedef void* GO_OSSL_PARAM_PTR;
 typedef void* GO_CRYPTO_THREADID_PTR;
 typedef void* GO_EVP_SIGNATURE_PTR;
 typedef void* GO_DSA_PTR;
+typedef void* GO_EVP_KDF_PTR;
+typedef void* GO_EVP_KDF_CTX_PTR;
+
 
 // #include <openssl/md5.h>
 typedef void* GO_MD5_CTX_PTR;
@@ -375,9 +378,6 @@ DEFINEFUNC_3_0(int, EVP_PKEY_up_ref, (GO_EVP_PKEY_PTR key), (key)) \
 DEFINEFUNC_LEGACY_1(int, EVP_PKEY_set1_EC_KEY, (GO_EVP_PKEY_PTR pkey, GO_EC_KEY_PTR key), (pkey, key)) \
 DEFINEFUNC_3_0(int, EVP_PKEY_CTX_set0_rsa_oaep_label, (GO_EVP_PKEY_CTX_PTR ctx, void *label, int len), (ctx, label, len)) \
 DEFINEFUNC(int, PKCS5_PBKDF2_HMAC, (const char *pass, int passlen, const unsigned char *salt, int saltlen, int iter, const GO_EVP_MD_PTR digest, int keylen, unsigned char *out), (pass, passlen, salt, saltlen, iter, digest, keylen, out)) \
-DEFINEFUNC_3_0(int, EVP_PKEY_CTX_set_tls1_prf_md, (GO_EVP_PKEY_CTX_PTR arg0, const GO_EVP_MD_PTR arg1), (arg0, arg1)) \
-DEFINEFUNC_3_0(int, EVP_PKEY_CTX_set1_tls1_prf_secret, (GO_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2), (arg0, arg1, arg2)) \
-DEFINEFUNC_3_0(int, EVP_PKEY_CTX_add1_tls1_prf_seed, (GO_EVP_PKEY_CTX_PTR arg0, const unsigned char *arg1, int arg2), (arg0, arg1, arg2)) \
 DEFINEFUNC_1_1_1(int, EVP_PKEY_get_raw_public_key, (const GO_EVP_PKEY_PTR pkey, unsigned char *pub, size_t *len), (pkey, pub, len)) \
 DEFINEFUNC_1_1_1(int, EVP_PKEY_get_raw_private_key, (const GO_EVP_PKEY_PTR pkey, unsigned char *priv, size_t *len), (pkey, priv, len)) \
 DEFINEFUNC_3_0(GO_EVP_SIGNATURE_PTR, EVP_SIGNATURE_fetch, (GO_OSSL_LIB_CTX_PTR ctx, const char *algorithm, const char *properties), (ctx, algorithm, properties)) \
@@ -389,4 +389,9 @@ DEFINEFUNC_LEGACY_1_1(void, DSA_get0_pqg, (const GO_DSA_PTR d, const GO_BIGNUM_P
 DEFINEFUNC_LEGACY_1_1(int, DSA_set0_pqg, (GO_DSA_PTR d, GO_BIGNUM_PTR p, GO_BIGNUM_PTR q, GO_BIGNUM_PTR g), (d, p, q, g)) \
 DEFINEFUNC_LEGACY_1_1(void, DSA_get0_key, (const GO_DSA_PTR d, const GO_BIGNUM_PTR *pub_key, const GO_BIGNUM_PTR *priv_key), (d, pub_key, priv_key)) \
 DEFINEFUNC_LEGACY_1_1(int, DSA_set0_key, (GO_DSA_PTR d, GO_BIGNUM_PTR pub_key, GO_BIGNUM_PTR priv_key), (d, pub_key, priv_key)) \
+DEFINEFUNC_3_0(GO_EVP_KDF_PTR, EVP_KDF_fetch, (GO_OSSL_LIB_CTX_PTR libctx, const char *algorithm, const char *properties), (libctx, algorithm, properties)) \
+DEFINEFUNC_3_0(void, EVP_KDF_free, (GO_EVP_KDF_PTR kdf), (kdf)) \
+DEFINEFUNC_3_0(GO_EVP_KDF_CTX_PTR, EVP_KDF_CTX_new, (GO_EVP_KDF_PTR kdf), (kdf)) \
+DEFINEFUNC_3_0(void, EVP_KDF_CTX_free, (GO_EVP_KDF_CTX_PTR ctx), (ctx)) \
+DEFINEFUNC_3_0(int, EVP_KDF_derive, (GO_EVP_KDF_CTX_PTR ctx, unsigned char *key, size_t keylen, const GO_OSSL_PARAM_PTR params), (ctx, key, keylen, params)) \
 

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -8,12 +8,20 @@ import (
 	"crypto"
 	"errors"
 	"hash"
+	"sync"
 	"unsafe"
 )
 
 func SupportsTLS1PRF() bool {
-	return vMajor > 1 ||
-		(vMajor >= 1 && vMinor >= 1)
+	switch vMajor {
+	case 1:
+		return vMajor > 1 || (vMajor >= 1 && vMinor >= 1)
+	case 3:
+		_, err := fetchTLS1PRF()
+		return err == nil
+	default:
+		panic(errUnsupportedVersion())
+	}
 }
 
 // TLS1PRF implements the TLS 1.0/1.1 pseudo-random function if h is nil,
@@ -35,6 +43,20 @@ func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
 		return errors.New("unsupported hash function")
 	}
 
+	switch vMajor {
+	case 1:
+		return tls1PRF1(result, secret, label, seed, md)
+	case 3:
+		return tls1PRF3(result, secret, label, seed, md)
+	default:
+		return errUnsupportedVersion()
+	}
+}
+
+// tls1PRF1 implements TLS1PRF for OpenSSL 1 using the EVP_PKEY API.
+func tls1PRF1(result, secret, label, seed []byte, md C.GO_EVP_MD_PTR) error {
+	checkMajorVersion(1)
+
 	ctx := C.go_openssl_EVP_PKEY_CTX_new_id(C.GO_EVP_PKEY_TLS1_PRF, nil)
 	if ctx == nil {
 		return newOpenSSLError("EVP_PKEY_CTX_new_id")
@@ -46,48 +68,29 @@ func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
 	if C.go_openssl_EVP_PKEY_derive_init(ctx) != 1 {
 		return newOpenSSLError("EVP_PKEY_derive_init")
 	}
-	switch vMajor {
-	case 3:
-		if C.go_openssl_EVP_PKEY_CTX_set_tls1_prf_md(ctx, md) != 1 {
-			return newOpenSSLError("EVP_PKEY_CTX_set_tls1_prf_md")
-		}
-		if C.go_openssl_EVP_PKEY_CTX_set1_tls1_prf_secret(ctx,
-			base(secret), C.int(len(secret))) != 1 {
-			return newOpenSSLError("EVP_PKEY_CTX_set1_tls1_prf_secret")
-		}
-		if C.go_openssl_EVP_PKEY_CTX_add1_tls1_prf_seed(ctx,
-			base(label), C.int(len(label))) != 1 {
-			return newOpenSSLError("EVP_PKEY_CTX_add1_tls1_prf_seed")
-		}
-		if C.go_openssl_EVP_PKEY_CTX_add1_tls1_prf_seed(ctx,
-			base(seed), C.int(len(seed))) != 1 {
-			return newOpenSSLError("EVP_PKEY_CTX_add1_tls1_prf_seed")
-		}
-	case 1:
-		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
-			C.GO1_EVP_PKEY_OP_DERIVE,
-			C.GO_EVP_PKEY_CTRL_TLS_MD,
-			0, unsafe.Pointer(md)) != 1 {
-			return newOpenSSLError("EVP_PKEY_CTX_set_tls1_prf_md")
-		}
-		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
-			C.GO1_EVP_PKEY_OP_DERIVE,
-			C.GO_EVP_PKEY_CTRL_TLS_SECRET,
-			C.int(len(secret)), unsafe.Pointer(base(secret))) != 1 {
-			return newOpenSSLError("EVP_PKEY_CTX_set1_tls1_prf_secret")
-		}
-		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
-			C.GO1_EVP_PKEY_OP_DERIVE,
-			C.GO_EVP_PKEY_CTRL_TLS_SEED,
-			C.int(len(label)), unsafe.Pointer(base(label))) != 1 {
-			return newOpenSSLError("EVP_PKEY_CTX_add1_tls1_prf_seed")
-		}
-		if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
-			C.GO1_EVP_PKEY_OP_DERIVE,
-			C.GO_EVP_PKEY_CTRL_TLS_SEED,
-			C.int(len(seed)), unsafe.Pointer(base(seed))) != 1 {
-			return newOpenSSLError("EVP_PKEY_CTX_add1_tls1_prf_seed")
-		}
+	if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
+		C.GO1_EVP_PKEY_OP_DERIVE,
+		C.GO_EVP_PKEY_CTRL_TLS_MD,
+		0, unsafe.Pointer(md)) != 1 {
+		return newOpenSSLError("EVP_PKEY_CTX_set_tls1_prf_md")
+	}
+	if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
+		C.GO1_EVP_PKEY_OP_DERIVE,
+		C.GO_EVP_PKEY_CTRL_TLS_SECRET,
+		C.int(len(secret)), unsafe.Pointer(base(secret))) != 1 {
+		return newOpenSSLError("EVP_PKEY_CTX_set1_tls1_prf_secret")
+	}
+	if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
+		C.GO1_EVP_PKEY_OP_DERIVE,
+		C.GO_EVP_PKEY_CTRL_TLS_SEED,
+		C.int(len(label)), unsafe.Pointer(base(label))) != 1 {
+		return newOpenSSLError("EVP_PKEY_CTX_add1_tls1_prf_seed")
+	}
+	if C.go_openssl_EVP_PKEY_CTX_ctrl(ctx, -1,
+		C.GO1_EVP_PKEY_OP_DERIVE,
+		C.GO_EVP_PKEY_CTRL_TLS_SEED,
+		C.int(len(seed)), unsafe.Pointer(base(seed))) != 1 {
+		return newOpenSSLError("EVP_PKEY_CTX_add1_tls1_prf_seed")
 	}
 	outLen := C.size_t(len(result))
 	if C.go_openssl_EVP_PKEY_derive_wrapper(ctx, base(result), outLen).result != 1 {
@@ -99,6 +102,55 @@ func TLS1PRF(result, secret, label, seed []byte, h func() hash.Hash) error {
 	// after more code changes in the future.
 	if outLen != C.size_t(len(result)) {
 		return errors.New("tls1-prf: derived less bytes than requested")
+	}
+	return nil
+}
+
+// fetchTLS1PRF fetches the TLS1-PRF KDF algorithm.
+// It is safe to call this function concurrently.
+// The returned EVP_KDF_PTR shouldn't be freed.
+var fetchTLS1PRF = sync.OnceValues(func() (C.GO_EVP_KDF_PTR, error) {
+	checkMajorVersion(3)
+
+	name := C.CString("TLS1-PRF")
+	kdf := C.go_openssl_EVP_KDF_fetch(nil, name, nil)
+	C.free(unsafe.Pointer(name))
+	if kdf == nil {
+		return nil, newOpenSSLError("EVP_KDF_fetch")
+	}
+	return kdf, nil
+})
+
+// tls1PRF3 implements TLS1PRF for OpenSSL 3 using the EVP_KDF API.
+func tls1PRF3(result, secret, label, seed []byte, md C.GO_EVP_MD_PTR) error {
+	checkMajorVersion(3)
+
+	kdf, err := fetchTLS1PRF()
+	if err != nil {
+		return err
+	}
+	ctx := C.go_openssl_EVP_KDF_CTX_new(kdf)
+	if ctx == nil {
+		return newOpenSSLError("EVP_KDF_CTX_new")
+	}
+	defer C.go_openssl_EVP_KDF_CTX_free(ctx)
+
+	bld, err := newParamBuilder()
+	if err != nil {
+		return err
+	}
+	bld.addUtf8String(_OSSL_KDF_PARAM_DIGEST, C.go_openssl_EVP_MD_get0_name(md), 0)
+	bld.addOctetString(_OSSL_KDF_PARAM_SECRET, secret)
+	bld.addOctetString(_OSSL_KDF_PARAM_SEED, label)
+	bld.addOctetString(_OSSL_KDF_PARAM_SEED, seed)
+	params, err := bld.build()
+	if err != nil {
+		return err
+	}
+	defer C.go_openssl_OSSL_PARAM_free(params)
+
+	if C.go_openssl_EVP_KDF_derive(ctx, base(result), C.size_t(len(result)), params) != 1 {
+		return newOpenSSLError("EVP_KDF_derive")
 	}
 	return nil
 }

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -139,7 +139,7 @@ func tls1PRF3(result, secret, label, seed []byte, md C.GO_EVP_MD_PTR) error {
 	if err != nil {
 		return err
 	}
-	bld.addUtf8String(_OSSL_KDF_PARAM_DIGEST, C.go_openssl_EVP_MD_get0_name(md), 0)
+	bld.addUTF8String(_OSSL_KDF_PARAM_DIGEST, C.go_openssl_EVP_MD_get0_name(md), 0)
 	bld.addOctetString(_OSSL_KDF_PARAM_SECRET, secret)
 	bld.addOctetString(_OSSL_KDF_PARAM_SEED, label)
 	bld.addOctetString(_OSSL_KDF_PARAM_SEED, seed)

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -17,7 +17,7 @@ func SupportsTLS1PRF() bool {
 	case 1:
 		return vMinor >= 1
 	case 3:
-		_, err := fetchTLS1PRF()
+		_, err := fetchTLS1PRF3()
 		return err == nil
 	default:
 		panic(errUnsupportedVersion())
@@ -106,10 +106,10 @@ func tls1PRF1(result, secret, label, seed []byte, md C.GO_EVP_MD_PTR) error {
 	return nil
 }
 
-// fetchTLS1PRF fetches the TLS1-PRF KDF algorithm.
+// fetchTLS1PRF3 fetches the TLS1-PRF KDF algorithm.
 // It is safe to call this function concurrently.
 // The returned EVP_KDF_PTR shouldn't be freed.
-var fetchTLS1PRF = sync.OnceValues(func() (C.GO_EVP_KDF_PTR, error) {
+var fetchTLS1PRF3 = sync.OnceValues(func() (C.GO_EVP_KDF_PTR, error) {
 	checkMajorVersion(3)
 
 	name := C.CString("TLS1-PRF")
@@ -125,7 +125,7 @@ var fetchTLS1PRF = sync.OnceValues(func() (C.GO_EVP_KDF_PTR, error) {
 func tls1PRF3(result, secret, label, seed []byte, md C.GO_EVP_MD_PTR) error {
 	checkMajorVersion(3)
 
-	kdf, err := fetchTLS1PRF()
+	kdf, err := fetchTLS1PRF3()
 	if err != nil {
 		return err
 	}

--- a/tls1prf.go
+++ b/tls1prf.go
@@ -15,7 +15,7 @@ import (
 func SupportsTLS1PRF() bool {
 	switch vMajor {
 	case 1:
-		return vMajor > 1 || (vMajor >= 1 && vMinor >= 1)
+		return vMinor >= 1
 	case 3:
 		_, err := fetchTLS1PRF()
 		return err == nil

--- a/tls1prf_test.go
+++ b/tls1prf_test.go
@@ -147,7 +147,7 @@ var tls1prfTests = []tls1prfTest{
 
 func TestTLS1PRF(t *testing.T) {
 	if !openssl.SupportsTLS1PRF() {
-		t.Skip("TLS PRF is not supported")
+		t.Skip("TLS1 PRF is not supported")
 	}
 	for _, tt := range tls1prfTests {
 		t.Run(tt.hash.String(), func(t *testing.T) {


### PR DESCRIPTION
The [EVP_KDF](https://docs.openssl.org/master/man3/EVP_KDF/) API was added in OpenSSL 3 to properly support KDF algorithms, such as TLS1 PRF. It is recommended that KDF operations migrates from the EVP_PKEY API to this new API. The built-in providers still support the EVP_PKEY for back compat, but third party provider might not do it (SymCrypt looking at you).

This PR implements TLS1 PRF using the EVP_KDF API when using OpenSSL 3.

Also, I'm introducing a new helper, `paramBuilder`,  to build parameters in a much cleaner and safer way. I'll submit a follow-up PR using this helper in other algorithms.

For #158.
For #189.
