### PR TITLE
Add Mariner 2 to Github Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,3 +89,11 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Run Test
       run: go test -v ./...
+  mariner2:
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-3-cbl-mariner2.0
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Run Test
+      run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
       run: go test -v ./...
   mariner2:
     runs-on: ubuntu-latest
+    # This line is temporary. We are currently working on a fix to fully support Mariner 2.0. Once the fix is merged, we will remove this line.    
     continue-on-error: true
     container: mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-3-cbl-mariner2.0
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,11 +91,11 @@ jobs:
       run: go test -v ./...
   mariner2:
     runs-on: ubuntu-latest
-    # This line is temporary. We are currently working on a fix to fully support Mariner 2.0. Once the fix is merged, we will remove this line.    
-    continue-on-error: true
     container: mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-3-cbl-mariner2.0
     steps:
     - name: Checkout code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Run Test
+      # This line is temporary. We are currently working on a fix to fully support Mariner 2.0. Once the fix is merged, we will remove this line.    
+      continue-on-error: true
       run: go test -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,6 +91,7 @@ jobs:
       run: go test -v ./...
   mariner2:
     runs-on: ubuntu-latest
+    continue-on-error: true
     container: mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-3-cbl-mariner2.0
     steps:
     - name: Checkout code


### PR DESCRIPTION
Our clients using Mariner 2 have been experiencing panics. To mitigate these issues, this pull request introduces changes to the GitHub workflow YAML file, enabling automated testing on Mariner 2 as well.